### PR TITLE
Implement PixelAnalytics backend, ETL, and frontend scaffold

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.php]
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+APP_ENV=prod
+TIMEZONE=Europe/Moscow
+
+# Прод-БД (чтение сырых заказов)
+PROD_DB_HOST=127.0.0.1
+PROD_DB_NAME=app_db
+PROD_DB_USER=user
+PROD_DB_PASS=pass
+PROD_DB_CHARSET=utf8
+
+# Аналитическая БД (запись/чтение)
+AN_DB_HOST=127.0.0.1
+AN_DB_NAME=analytics
+AN_DB_USER=an_user
+AN_DB_PASS=an_pass
+AN_DB_CHARSET=utf8
+
+# VK API
+VK_API_VERSION=5.199
+VK_ACCESS_TOKEN=replace_me
+VK_BATCH_SIZE=100
+VK_FETCH_COOLDOWN_DAYS=30
+
+# API
+HTTP_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+/vendor/
+/backend/vendor/
+!/backend/vendor/autoload.php
+/frontend/node_modules/
+/frontend/dist/
+/.env
+/backend/.env
+/scripts/logs/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+composer.lock
+package-lock.json
+pnpm-lock.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PixelAnalytics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# pixelAnalitics
+# PixelAnalytics
+
+PixelAnalytics — минимальный аналитический стек для e-commerce с витриной показателей и простыми ETL-скриптами.
+
+## Структура репозитория
+
+```
+pixel-analytics/
+├── backend/            # PHP 5.6 API + ETL классы
+├── frontend/           # React SPA на Vite
+├── sql/                # DWH схема и сиды
+├── cli/                # CLI-скрипты ETL
+└── scripts/            # установка, миграции и cron
+```
+
+## Быстрый старт
+
+1. Убедитесь, что установлены PHP ≥5.6, MySQL ≥5.6 и Node.js 16.x.
+2. Скопируйте `.env.example` в `.env` и заполните доступы:
+   * `PROD_DB_*` — доступ только на чтение к боевой БД заказов;
+   * `AN_DB_*` — доступ на чтение/запись к аналитической БД;
+   * `VK_*` — токен и параметры API ВКонтакте;
+   * `TIMEZONE` — таймзона (по умолчанию Europe/Moscow).
+3. Запустите установку: `bash scripts/install.sh`
+   * Скрипт проверит версии, создаст БД `analytics`, применит `sql/*.sql` и соберёт фронтенд.
+4. Для повторного применения схемы используйте `bash scripts/migrate.sh`.
+
+## Запуск API
+
+API — это `php -S 0.0.0.0:$HTTP_PORT -t backend/public`. По умолчанию порт 8080. Эндпоинты возвращают JSON и кэшируются файлом на 5–15 минут.
+
+Доступные маршруты:
+
+| Метод | Путь | Описание |
+| ----- | ---- | -------- |
+| GET | `/api/health` | Проверка состояния сервиса |
+| GET | `/api/kpi?period=30d` | Оборот, заказы, средний чек, ретеншн |
+| GET | `/api/segments/compare?periods=2` | Сравнение сегментов WoW |
+| GET | `/api/rfm?filter=r>=4&f>=3&m>=3&limit=100` | Топ пользователей по RFM |
+| GET | `/api/products/daily?from=YYYY-MM-DD&to=YYYY-MM-DD` | Дневной тренд продаж |
+| GET | `/api/cohorts` | Когортная таблица (последние 12) |
+
+## ETL-процессы
+
+### cli/etl_extract.php
+
+* Инкрементально копирует новые заказы из прод-БД в `stg_*`, затем апсертом обновляет `dim_user`, `dim_product`, `fact_orders`, `fact_order_items`.
+* Водяной знак `orders_last_id` хранится в `etl_watermarks`.
+* Телефоны хэшируются через SHA256 → BINARY(32).
+* Логи записываются в `scripts/logs/etl_extract.log`.
+
+### cli/etl_vk_update.php
+
+* Ищет пользователей с `vk_id` без профиля или устаревшим `fetched_at` (старше `VK_FETCH_COOLDOWN_DAYS`).
+* Обращается к VK API батчами по 100 с задержкой 0.35–0.5 с и повтором при `too many requests`.
+* Обновляет таблицу `vk_profiles` и сохраняет сырой ответ в `raw_json`.
+
+### cli/etl_build_summaries.php
+
+* Пересчитывает `summary_rfm`, `summary_segments_daily` (за последние 7 дней), `summary_products_daily` (30 дней) и `summary_cohorts`.
+* Скрипты возвращают код 0 при успехе и печатают краткую сводку.
+
+Пример cron (`scripts/cron_examples.txt`):
+
+```
+0 3 * * *  /usr/bin/php /var/www/pixel-analytics/cli/etl_extract.php >> /var/log/pixel-analytics/etl_extract.log 2>&1
+10 3 * * * /usr/bin/php /var/www/pixel-analytics/cli/etl_vk_update.php >> /var/log/pixel-analytics/etl_vk_update.log 2>&1
+30 3 * * * /usr/bin/php /var/www/pixel-analytics/cli/etl_build_summaries.php >> /var/log/pixel-analytics/etl_build_summaries.log 2>&1
+```
+
+## Фронтенд
+
+* React 18 + Vite.
+* В виджетах используются `chart.js` + `react-chartjs-2`.
+* Сборка: `cd frontend && npm install && npm run build`.
+* Готовые файлы появляются в `frontend/dist` и могут быть отданы любым веб-сервером.
+
+## Рабочий процесс аналитики
+
+1. **Extract** — вытягивает инкрементальные заказы и пользователей, обновляет витрины.
+2. **VK Enrich** — пополняет демографию через VK API (с уважением к флагу `do_not_profile`).
+3. **Build Summaries** — собирает RFM, сегменты, продукты и когорты для BI-дашборда.
+4. **API** — отдаёт данные SPA и внешним системам (по необходимости).
+5. **SPA** — визуализирует KPI, сравнение сегментов, тепловую карту RFM, тренды и когорты.
+
+## Подготовка тестовых данных
+
+* После развёртывания схемы можно вставить тестовые строки в `stg_*` и `fact_*`, затем запустить `cli/etl_build_summaries.php`.
+* Для VK достаточно заполнить `stg_users.vk_id` и запустить `cli/etl_vk_update.php` (понадобится валидный токен).
+
+## Безопасность
+
+* Флаг `dim_user.do_not_profile = 1` исключает пользователя из обогащения и аналитики.
+* Телефон хранится только в виде `phone_sha256`.
+* Токены VK задаются через `.env`, не коммитятся в репозиторий.
+

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "pixel-analytics/backend",
+  "description": "PixelAnalytics backend",
+  "type": "project",
+  "require": {},
+  "autoload": {
+    "psr-4": {
+      "PixelAnalytics\\": "src/"
+    }
+  }
+}

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use PixelAnalytics\Api\Router;
+use PixelAnalytics\Config;
+use PixelAnalytics\Helpers\Env;
+
+if (!class_exists('Dotenv')) {
+    // basic .env loader to keep php -S usable without composer dumps
+    Env::bootstrap(dirname(__DIR__) . '/../.env');
+}
+
+Config::init();
+
+$router = new Router();
+$router->registerDefaults();
+
+$response = $router->dispatch($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
+
+http_response_code($response['status']);
+if (!headers_sent()) {
+    header('Content-Type: application/json; charset=utf-8');
+}
+
+echo json_encode($response['body']);

--- a/backend/src/Api/Controllers/CohortsController.php
+++ b/backend/src/Api/Controllers/CohortsController.php
@@ -1,0 +1,16 @@
+<?php
+namespace PixelAnalytics\Api\Controllers;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Json;
+
+class CohortsController
+{
+    public function index()
+    {
+        $db = Db::analytics();
+        $sql = 'SELECT * FROM summary_cohorts ORDER BY cohort_month DESC LIMIT 12';
+        $rows = Db::query($db, $sql);
+        return Json::success(array('items' => $rows));
+    }
+}

--- a/backend/src/Api/Controllers/HealthController.php
+++ b/backend/src/Api/Controllers/HealthController.php
@@ -1,0 +1,15 @@
+<?php
+namespace PixelAnalytics\Api\Controllers;
+
+use PixelAnalytics\Helpers\Json;
+
+class HealthController
+{
+    public function index()
+    {
+        return Json::success(array(
+            'status' => 'ok',
+            'time' => date('c'),
+        ));
+    }
+}

--- a/backend/src/Api/Controllers/KpiController.php
+++ b/backend/src/Api/Controllers/KpiController.php
@@ -1,0 +1,43 @@
+<?php
+namespace PixelAnalytics\Api\Controllers;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Json;
+
+class KpiController
+{
+    public function index($query)
+    {
+        $period = isset($query['period']) ? $query['period'] : '30d';
+        $days = $this->parseDays($period);
+        $startDate = date('Y-m-d', strtotime('-' . ($days - 1) . ' days'));
+        $endDate = date('Y-m-d');
+
+        $db = Db::analytics();
+        $sql = 'SELECT
+                SUM(revenue_sum) AS revenue,
+                SUM(orders_cnt) AS orders,
+                SUM(revenue_sum) / NULLIF(SUM(orders_cnt), 0) AS avg_check,
+                SUM(repeat_rate_90d * users_cnt) / NULLIF(SUM(users_cnt), 0) AS retention
+            FROM summary_segments_daily
+            WHERE stat_date BETWEEN ? AND ?';
+        $rows = Db::query($db, $sql, array($startDate, $endDate));
+        $row = !empty($rows) ? $rows[0] : array('revenue' => 0, 'orders' => 0, 'avg_check' => 0, 'retention' => 0);
+
+        return Json::success(array(
+            'period' => $period,
+            'revenue' => (float) $row['revenue'],
+            'orders' => (int) $row['orders'],
+            'avg_check' => isset($row['avg_check']) ? (float) $row['avg_check'] : 0,
+            'retention' => isset($row['retention']) ? (float) $row['retention'] : 0,
+        ));
+    }
+
+    private function parseDays($period)
+    {
+        if (preg_match('/^(\d+)d$/', $period, $matches)) {
+            return max(1, (int) $matches[1]);
+        }
+        return 30;
+    }
+}

--- a/backend/src/Api/Controllers/ProductsController.php
+++ b/backend/src/Api/Controllers/ProductsController.php
@@ -1,0 +1,28 @@
+<?php
+namespace PixelAnalytics\Api\Controllers;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Json;
+
+class ProductsController
+{
+    public function daily($query)
+    {
+        $from = isset($query['from']) ? $query['from'] : date('Y-m-d', strtotime('-30 days'));
+        $to = isset($query['to']) ? $query['to'] : date('Y-m-d');
+
+        $db = Db::analytics();
+        $sql = 'SELECT date, SUM(orders_cnt) AS orders_cnt, SUM(qty_sum) AS qty_sum, SUM(revenue_sum) AS revenue_sum
+            FROM summary_products_daily
+            WHERE date BETWEEN ? AND ?
+            GROUP BY date
+            ORDER BY date ASC';
+        $rows = Db::query($db, $sql, array($from, $to));
+
+        return Json::success(array(
+            'from' => $from,
+            'to' => $to,
+            'series' => $rows,
+        ));
+    }
+}

--- a/backend/src/Api/Controllers/RfmController.php
+++ b/backend/src/Api/Controllers/RfmController.php
@@ -1,0 +1,59 @@
+<?php
+namespace PixelAnalytics\Api\Controllers;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Json;
+
+class RfmController
+{
+    private $fieldMap = array(
+        'r' => 'r_class',
+        'f' => 'f_class',
+        'm' => 'm_class',
+    );
+
+    public function index($query)
+    {
+        $filter = isset($query['filter']) ? $query['filter'] : '';
+        $limit = isset($query['limit']) ? (int) $query['limit'] : 100;
+        $limit = max(1, min($limit, 500));
+
+        list($where, $params) = $this->buildWhere($filter);
+        $sql = 'SELECT user_id, recency_days, frequency_90d, monetary_90d, r_class, f_class, m_class, segment_label
+            FROM summary_rfm';
+        if ($where) {
+            $sql .= ' WHERE ' . $where;
+        }
+        $sql .= ' ORDER BY monetary_90d DESC LIMIT ' . $limit;
+
+        $db = Db::analytics();
+        $rows = Db::query($db, $sql, $params);
+
+        return Json::success(array(
+            'total' => count($rows),
+            'items' => $rows,
+        ));
+    }
+
+    private function buildWhere($filter)
+    {
+        if (empty($filter)) {
+            return array('', array());
+        }
+        $parts = explode('&', $filter);
+        $clauses = array();
+        $params = array();
+        foreach ($parts as $part) {
+            if (!preg_match('/^(r|f|m)([<>]=?)(\d)$/', $part, $matches)) {
+                continue;
+            }
+            $column = $this->fieldMap[$matches[1]];
+            $operator = $matches[2];
+            $value = (int) $matches[3];
+            $clauses[] = $column . ' ' . $operator . ' ?';
+            $params[] = $value;
+        }
+        $where = implode(' AND ', $clauses);
+        return array($where, $params);
+    }
+}

--- a/backend/src/Api/Controllers/SegmentsController.php
+++ b/backend/src/Api/Controllers/SegmentsController.php
@@ -1,0 +1,109 @@
+<?php
+namespace PixelAnalytics\Api\Controllers;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Json;
+
+class SegmentsController
+{
+    public function compare($query)
+    {
+        $periods = isset($query['periods']) ? (int) $query['periods'] : 2;
+        $periods = max(1, min($periods, 4));
+        $daysBack = $periods * 7;
+        $endDate = date('Y-m-d', strtotime('sunday last week'));
+        $startDate = date('Y-m-d', strtotime('-' . ($daysBack - 1) . ' days', strtotime($endDate)));
+
+        $db = Db::analytics();
+        $sql = 'SELECT YEARWEEK(stat_date, 1) AS wk, sex, age_bucket, city,
+                SUM(revenue_sum) AS revenue_sum,
+                SUM(orders_cnt) AS orders_cnt,
+                SUM(users_cnt) AS users_cnt
+            FROM summary_segments_daily
+            WHERE stat_date BETWEEN ? AND ?
+            GROUP BY wk, sex, age_bucket, city';
+        $rows = Db::query($db, $sql, array($startDate, $endDate));
+
+        $weeks = array();
+        foreach ($rows as $row) {
+            $week = $row['wk'];
+            if (!isset($weeks[$week])) {
+                $weeks[$week] = array();
+            }
+            $key = $this->buildKey($row['sex'], $row['age_bucket'], $row['city']);
+            $weeks[$week][$key] = array(
+                'key' => $key,
+                'sex' => $row['sex'],
+                'age_bucket' => $row['age_bucket'],
+                'city' => $row['city'],
+                'revenue' => (float) $row['revenue_sum'],
+                'orders' => (int) $row['orders_cnt'],
+                'users' => (int) $row['users_cnt'],
+            );
+        }
+
+        ksort($weeks);
+        $weekKeys = array_keys($weeks);
+        $countWeeks = count($weekKeys);
+        if ($countWeeks < 2) {
+            return Json::success(array('groups' => array(), 'weeks' => $weekKeys));
+        }
+
+        $currentWeek = $weekKeys[$countWeeks - 1];
+        $previousWeek = $weekKeys[$countWeeks - 2];
+
+        $currentData = isset($weeks[$currentWeek]) ? $weeks[$currentWeek] : array();
+        $previousData = isset($weeks[$previousWeek]) ? $weeks[$previousWeek] : array();
+
+        $allKeys = array_unique(array_merge(array_keys($currentData), array_keys($previousData)));
+        $groups = array();
+        foreach ($allKeys as $key) {
+            $current = isset($currentData[$key]) ? $currentData[$key] : $this->emptyGroup($key);
+            $previous = isset($previousData[$key]) ? $previousData[$key] : $this->emptyGroup($key);
+            $meta = $current['sex'] !== null ? $current : $previous;
+            $groups[] = array(
+                'key' => $key,
+                'sex' => $meta['sex'],
+                'age_bucket' => $meta['age_bucket'],
+                'city' => $meta['city'],
+                'current' => $current,
+                'previous' => $previous,
+                'wow_revenue' => $this->deltaPercent($previous['revenue'], $current['revenue']),
+                'wow_orders' => $this->deltaPercent($previous['orders'], $current['orders']),
+                'wow_users' => $this->deltaPercent($previous['users'], $current['users']),
+            );
+        }
+
+        return Json::success(array(
+            'weeks' => array('previous' => $previousWeek, 'current' => $currentWeek),
+            'groups' => $groups,
+        ));
+    }
+
+    private function buildKey($sex, $age, $city)
+    {
+        return implode(':', array($sex, $age, $city));
+    }
+
+    private function emptyGroup($key)
+    {
+        $parts = explode(':', $key);
+        return array(
+            'key' => $key,
+            'sex' => isset($parts[0]) ? $parts[0] : null,
+            'age_bucket' => isset($parts[1]) ? $parts[1] : 'unknown',
+            'city' => isset($parts[2]) ? $parts[2] : 'unknown',
+            'revenue' => 0.0,
+            'orders' => 0,
+            'users' => 0,
+        );
+    }
+
+    private function deltaPercent($previous, $current)
+    {
+        if ($previous == 0) {
+            return $current > 0 ? 100.0 : 0.0;
+        }
+        return ($current - $previous) / $previous * 100.0;
+    }
+}

--- a/backend/src/Api/Router.php
+++ b/backend/src/Api/Router.php
@@ -1,0 +1,67 @@
+<?php
+namespace PixelAnalytics\Api;
+
+use PixelAnalytics\Helpers\Cache;
+use PixelAnalytics\Helpers\Json;
+use PixelAnalytics\Api\Controllers\HealthController;
+use PixelAnalytics\Api\Controllers\KpiController;
+use PixelAnalytics\Api\Controllers\SegmentsController;
+use PixelAnalytics\Api\Controllers\RfmController;
+use PixelAnalytics\Api\Controllers\ProductsController;
+use PixelAnalytics\Api\Controllers\CohortsController;
+
+class Router
+{
+    private $routes = array();
+    private $cache;
+
+    public function __construct()
+    {
+        $this->cache = new Cache(__DIR__ . '/../../cache');
+    }
+
+    public function registerDefaults()
+    {
+        $this->get('/api/health', array(new HealthController(), 'index'), 60);
+        $this->get('/api/kpi', array(new KpiController(), 'index'), 300);
+        $this->get('/api/segments/compare', array(new SegmentsController(), 'compare'), 600);
+        $this->get('/api/rfm', array(new RfmController(), 'index'), 600);
+        $this->get('/api/products/daily', array(new ProductsController(), 'daily'), 600);
+        $this->get('/api/cohorts', array(new CohortsController(), 'index'), 900);
+    }
+
+    public function get($path, $handler, $ttl = 0)
+    {
+        $this->routes['GET'][$path] = array('handler' => $handler, 'ttl' => $ttl);
+    }
+
+    public function dispatch($method, $uri)
+    {
+        $path = parse_url($uri, PHP_URL_PATH);
+        if (!isset($this->routes[$method][$path])) {
+            return Json::error('Not Found', 404);
+        }
+
+        $route = $this->routes[$method][$path];
+        $handler = $route['handler'];
+        $ttl = isset($route['ttl']) ? (int) $route['ttl'] : 0;
+
+        if ($ttl > 0) {
+            $cacheKey = $path . '?' . http_build_query($_GET);
+            $payload = $this->cache->remember($cacheKey, $ttl, function () use ($handler) {
+                return call_user_func($handler, $_GET);
+            });
+            if (!headers_sent()) {
+                header('Cache-Control: public, max-age=' . $ttl);
+            }
+        } else {
+            $payload = call_user_func($handler, $_GET);
+        }
+
+        if (!is_array($payload) || !isset($payload['status'])) {
+            return Json::success($payload);
+        }
+
+        return $payload;
+    }
+}

--- a/backend/src/Config.php
+++ b/backend/src/Config.php
@@ -1,0 +1,67 @@
+<?php
+namespace PixelAnalytics;
+
+use PixelAnalytics\Helpers\Env;
+
+class Config
+{
+    /** @var array */
+    private static $config = array();
+
+    public static function init()
+    {
+        if (!empty(self::$config)) {
+            return;
+        }
+
+        Env::bootstrap(dirname(__DIR__) . '/../.env');
+
+        self::$config = array(
+            'app_env' => Env::get('APP_ENV', 'prod'),
+            'timezone' => Env::get('TIMEZONE', 'Europe/Moscow'),
+            'prod_db' => array(
+                'host' => Env::get('PROD_DB_HOST'),
+                'name' => Env::get('PROD_DB_NAME'),
+                'user' => Env::get('PROD_DB_USER'),
+                'pass' => Env::get('PROD_DB_PASS'),
+                'charset' => Env::get('PROD_DB_CHARSET', 'utf8'),
+            ),
+            'analytics_db' => array(
+                'host' => Env::get('AN_DB_HOST'),
+                'name' => Env::get('AN_DB_NAME'),
+                'user' => Env::get('AN_DB_USER'),
+                'pass' => Env::get('AN_DB_PASS'),
+                'charset' => Env::get('AN_DB_CHARSET', 'utf8'),
+            ),
+            'vk' => array(
+                'api_version' => Env::get('VK_API_VERSION'),
+                'access_token' => Env::get('VK_ACCESS_TOKEN'),
+                'batch_size' => (int) Env::get('VK_BATCH_SIZE', 100),
+                'cooldown_days' => (int) Env::get('VK_FETCH_COOLDOWN_DAYS', 30),
+            ),
+            'http' => array(
+                'port' => (int) Env::get('HTTP_PORT', 8080),
+            ),
+        );
+
+        date_default_timezone_set(self::$config['timezone']);
+    }
+
+    public static function get($path, $default = null)
+    {
+        if (empty(self::$config)) {
+            self::init();
+        }
+
+        $parts = explode('.', $path);
+        $value = self::$config;
+        foreach ($parts as $part) {
+            if (!is_array($value) || !array_key_exists($part, $value)) {
+                return $default;
+            }
+            $value = $value[$part];
+        }
+
+        return $value;
+    }
+}

--- a/backend/src/Db.php
+++ b/backend/src/Db.php
@@ -1,0 +1,104 @@
+<?php
+namespace PixelAnalytics;
+
+use Exception;
+
+class Db
+{
+    /** @var array */
+    private static $connections = array();
+
+    public static function analytics()
+    {
+        return self::connect('analytics_db');
+    }
+
+    public static function production()
+    {
+        return self::connect('prod_db');
+    }
+
+    private static function connect($configKey)
+    {
+        if (isset(self::$connections[$configKey])) {
+            return self::$connections[$configKey];
+        }
+
+        $config = Config::get($configKey);
+        if (!$config) {
+            throw new Exception('Database configuration missing for ' . $configKey);
+        }
+
+        if (class_exists('\\SafeMySQL')) {
+            $safeMysqlConfig = array(
+                'user' => $config['user'],
+                'pass' => $config['pass'],
+                'db' => $config['name'],
+                'host' => $config['host'],
+                'charset' => $config['charset'],
+            );
+            self::$connections[$configKey] = new \SafeMySQL($safeMysqlConfig);
+        } else {
+            $mysqli = new \mysqli($config['host'], $config['user'], $config['pass'], $config['name']);
+            if ($mysqli->connect_errno) {
+                throw new Exception('Failed to connect to MySQL: ' . $mysqli->connect_error);
+            }
+            if (!empty($config['charset'])) {
+                $mysqli->set_charset($config['charset']);
+            }
+            self::$connections[$configKey] = $mysqli;
+        }
+
+        return self::$connections[$configKey];
+    }
+
+    public static function query($connection, $sql, $params = array())
+    {
+        if ($connection instanceof \SafeMySQL) {
+            return $connection->query($sql, $params);
+        }
+
+        if ($connection instanceof \mysqli) {
+            if (!empty($params)) {
+                $sql = self::prepareSql($connection, $sql, $params);
+            }
+
+            $result = $connection->query($sql);
+            if ($result === true) {
+                return true;
+            }
+            if ($result === false) {
+                throw new Exception('MySQL error: ' . $connection->error);
+            }
+            $rows = array();
+            if ($result instanceof \mysqli_result) {
+                while ($row = $result->fetch_assoc()) {
+                    $rows[] = $row;
+                }
+                $result->free();
+            }
+            return $rows;
+        }
+
+        throw new Exception('Unsupported connection type');
+    }
+
+    private static function prepareSql($connection, $sql, $params)
+    {
+        foreach ($params as $param) {
+            if ($param === null) {
+                $replacement = 'NULL';
+            } elseif (is_int($param) || is_float($param)) {
+                $replacement = (string) $param;
+            } else {
+                $replacement = "'" . $connection->real_escape_string($param) . "'";
+            }
+            $pos = strpos($sql, '?');
+            if ($pos === false) {
+                break;
+            }
+            $sql = substr_replace($sql, $replacement, $pos, 1);
+        }
+        return $sql;
+    }
+}

--- a/backend/src/Etl/BuildSummaries.php
+++ b/backend/src/Etl/BuildSummaries.php
@@ -1,0 +1,161 @@
+<?php
+namespace PixelAnalytics\Etl;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Date;
+use PixelAnalytics\Helpers\Logger;
+
+class BuildSummaries
+{
+    private $logger;
+
+    public function __construct(Logger $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function run()
+    {
+        $db = Db::analytics();
+        $this->rebuildRfm($db);
+        $this->rebuildSegments($db, 7);
+        $this->rebuildProducts($db, 30);
+        $this->rebuildCohorts($db);
+    }
+
+    private function rebuildRfm($db)
+    {
+        $this->logger->info('Rebuilding summary_rfm');
+        $sqlDelete = 'TRUNCATE TABLE summary_rfm';
+        Db::query($db, $sqlDelete);
+
+        $sqlInsert = "INSERT INTO summary_rfm (user_id, recency_days, frequency_90d, monetary_90d, r_class, f_class, m_class, segment_label)
+            SELECT
+                fo.user_id,
+                DATEDIFF(CURDATE(), MAX(fo.order_dt)) AS recency_days,
+                SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) AS frequency_90d,
+                SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN fo.sum_total ELSE 0 END) AS monetary_90d,
+                CASE
+                    WHEN DATEDIFF(CURDATE(), MAX(fo.order_dt)) <= 7 THEN 5
+                    WHEN DATEDIFF(CURDATE(), MAX(fo.order_dt)) <= 14 THEN 4
+                    WHEN DATEDIFF(CURDATE(), MAX(fo.order_dt)) <= 30 THEN 3
+                    WHEN DATEDIFF(CURDATE(), MAX(fo.order_dt)) <= 60 THEN 2
+                    ELSE 1
+                END AS r_class,
+                CASE
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) >= 10 THEN 5
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) >= 6 THEN 4
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) >= 3 THEN 3
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) >= 2 THEN 2
+                    ELSE 1
+                END AS f_class,
+                CASE
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN fo.sum_total ELSE 0 END) >= 50000 THEN 5
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN fo.sum_total ELSE 0 END) >= 20000 THEN 4
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN fo.sum_total ELSE 0 END) >= 10000 THEN 3
+                    WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN fo.sum_total ELSE 0 END) >= 5000 THEN 2
+                    ELSE 1
+                END AS m_class,
+                CONCAT(
+                    CASE
+                        WHEN DATEDIFF(CURDATE(), MAX(fo.order_dt)) <= 14 THEN 'active'
+                        ELSE 'churn_risk'
+                    END,
+                    '_',
+                    CASE
+                        WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) >= 6 THEN 'loyal'
+                        WHEN SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) >= 3 THEN 'regular'
+                        ELSE 'new'
+                    END
+                ) AS segment_label
+            FROM fact_orders fo
+            INNER JOIN dim_user du ON du.user_id = fo.user_id AND du.do_not_profile = 0
+            GROUP BY fo.user_id";
+        Db::query($db, $sqlInsert);
+    }
+
+    private function rebuildSegments($db, $days)
+    {
+        $this->logger->info('Rebuilding summary_segments_daily');
+        $endDate = Date::now();
+        $endDate->modify('-1 day');
+        $startDate = clone $endDate;
+        $startDate->modify('-' . ($days - 1) . ' day');
+
+        $sqlDelete = 'DELETE FROM summary_segments_daily WHERE stat_date BETWEEN ? AND ?';
+        Db::query($db, $sqlDelete, array($startDate->format('Y-m-d'), $endDate->format('Y-m-d')));
+
+        $sqlInsert = "INSERT INTO summary_segments_daily (stat_date, sex, age_bucket, city, users_cnt, orders_cnt, revenue_sum, avg_check, repeat_rate_90d)
+            SELECT
+                DATE(fo.order_dt) AS stat_date,
+                vp.sex,
+                CASE
+                    WHEN vp.age IS NULL THEN 'unknown'
+                    WHEN vp.age < 25 THEN '18-24'
+                    WHEN vp.age < 35 THEN '25-34'
+                    WHEN vp.age < 45 THEN '35-44'
+                    WHEN vp.age < 60 THEN '45-59'
+                    ELSE '60+'
+                END AS age_bucket,
+                COALESCE(vp.city, 'unknown') AS city,
+                COUNT(DISTINCT fo.user_id) AS users_cnt,
+                COUNT(*) AS orders_cnt,
+                SUM(fo.sum_total) AS revenue_sum,
+                IFNULL(AVG(fo.sum_total), 0) AS avg_check,
+                SUM(CASE WHEN fo.order_dt >= DATE_SUB(CURDATE(), INTERVAL 90 DAY) THEN 1 ELSE 0 END) / GREATEST(COUNT(DISTINCT fo.user_id), 1) AS repeat_rate_90d
+            FROM fact_orders fo
+            INNER JOIN dim_user du ON du.user_id = fo.user_id AND du.do_not_profile = 0
+            LEFT JOIN vk_profiles vp ON vp.user_id = fo.user_id
+            WHERE DATE(fo.order_dt) BETWEEN ? AND ?
+            GROUP BY stat_date, vp.sex, age_bucket, city";
+        Db::query($db, $sqlInsert, array($startDate->format('Y-m-d'), $endDate->format('Y-m-d')));
+    }
+
+    private function rebuildProducts($db, $days)
+    {
+        $this->logger->info('Rebuilding summary_products_daily');
+        $endDate = Date::now();
+        $endDate->modify('today');
+        $startDate = clone $endDate;
+        $startDate->modify('-' . $days . ' day');
+        $sqlDelete = 'DELETE FROM summary_products_daily WHERE date BETWEEN ? AND ?';
+        Db::query($db, $sqlDelete, array($startDate->format('Y-m-d'), $endDate->format('Y-m-d')));
+
+        $sqlInsert = "INSERT INTO summary_products_daily (date, product_id, orders_cnt, qty_sum, revenue_sum, unique_buyers)
+            SELECT
+                DATE(fo.order_dt) AS date,
+                foi.product_id,
+                COUNT(DISTINCT fo.order_id) AS orders_cnt,
+                SUM(foi.qty) AS qty_sum,
+                SUM(foi.amount) AS revenue_sum,
+                COUNT(DISTINCT fo.user_id) AS unique_buyers
+            FROM fact_orders fo
+            INNER JOIN fact_order_items foi ON foi.order_id = fo.order_id
+            WHERE DATE(fo.order_dt) BETWEEN ? AND ?
+            GROUP BY date, foi.product_id";
+        Db::query($db, $sqlInsert, array($startDate->format('Y-m-d'), $endDate->format('Y-m-d')));
+    }
+
+    private function rebuildCohorts($db)
+    {
+        $this->logger->info('Rebuilding summary_cohorts');
+        $sqlDelete = 'TRUNCATE TABLE summary_cohorts';
+        Db::query($db, $sqlDelete);
+
+        $sqlInsert = "INSERT INTO summary_cohorts (cohort_month, m0, m1, m2, m3, m4, m5, m6)
+            SELECT
+                DATE_FORMAT(du.first_order_dt, '%Y-%m-01') AS cohort_month,
+                SUM(CASE WHEN fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 1 MONTH) THEN 1 ELSE 0 END) AS m0,
+                SUM(CASE WHEN fo.order_dt >= DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 1 MONTH) AND fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 2 MONTH) THEN 1 ELSE 0 END) AS m1,
+                SUM(CASE WHEN fo.order_dt >= DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 2 MONTH) AND fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 3 MONTH) THEN 1 ELSE 0 END) AS m2,
+                SUM(CASE WHEN fo.order_dt >= DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 3 MONTH) AND fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 4 MONTH) THEN 1 ELSE 0 END) AS m3,
+                SUM(CASE WHEN fo.order_dt >= DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 4 MONTH) AND fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 5 MONTH) THEN 1 ELSE 0 END) AS m4,
+                SUM(CASE WHEN fo.order_dt >= DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 5 MONTH) AND fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 6 MONTH) THEN 1 ELSE 0 END) AS m5,
+                SUM(CASE WHEN fo.order_dt >= DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 6 MONTH) AND fo.order_dt < DATE_ADD(DATE_FORMAT(du.first_order_dt, '%Y-%m-01'), INTERVAL 7 MONTH) THEN 1 ELSE 0 END) AS m6
+            FROM dim_user du
+            LEFT JOIN fact_orders fo ON fo.user_id = du.user_id
+            WHERE du.first_order_dt IS NOT NULL
+            GROUP BY cohort_month";
+        Db::query($db, $sqlInsert);
+    }
+}

--- a/backend/src/Etl/EnrichVk.php
+++ b/backend/src/Etl/EnrichVk.php
@@ -1,0 +1,83 @@
+<?php
+namespace PixelAnalytics\Etl;
+
+use PixelAnalytics\Config;
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Date;
+use PixelAnalytics\Helpers\Logger;
+
+class EnrichVk
+{
+    private $logger;
+    private $client;
+    private $cooldownDays;
+
+    public function __construct(Logger $logger, VkClient $client)
+    {
+        $this->logger = $logger;
+        $this->client = $client;
+        $this->cooldownDays = (int) Config::get('vk.cooldown_days', 30);
+    }
+
+    public function findPendingUsers($limit = 500)
+    {
+        $db = Db::analytics();
+        $sql = 'SELECT su.id AS user_id, su.vk_id, vp.fetched_at, du.do_not_profile
+            FROM stg_users su
+            INNER JOIN dim_user du ON du.user_id = su.id
+            LEFT JOIN vk_profiles vp ON vp.user_id = su.id
+            WHERE su.vk_id IS NOT NULL AND du.do_not_profile = 0
+            AND (vp.user_id IS NULL OR vp.fetched_at <= DATE_SUB(NOW(), INTERVAL ? DAY))
+            LIMIT ?';
+        return Db::query($db, $sql, array($this->cooldownDays, $limit));
+    }
+
+    public function updateProfiles(array $candidates)
+    {
+        if (empty($candidates)) {
+            return array('updated' => 0, 'missed' => 0);
+        }
+
+        $vkIds = array();
+        $map = array();
+        foreach ($candidates as $candidate) {
+            $vkIds[] = $candidate['vk_id'];
+            $map[$candidate['vk_id']] = $candidate['user_id'];
+        }
+
+        $profiles = $this->client->fetchProfiles($vkIds);
+        $updated = 0;
+        $now = Date::formatSql(Date::now());
+        $db = Db::analytics();
+
+        foreach ($profiles as $profile) {
+            $vkId = $profile['vk_id'];
+            if (!isset($map[$vkId])) {
+                continue;
+            }
+            $userId = $map[$vkId];
+            $sql = 'REPLACE INTO vk_profiles (user_id, vk_id, sex, age, city, occupation, is_closed, last_seen, fetched_at, raw_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+            Db::query($db, $sql, array(
+                $userId,
+                $vkId,
+                $profile['sex'],
+                $profile['age'],
+                $profile['city'],
+                $profile['occupation'],
+                $profile['is_closed'],
+                $profile['last_seen'],
+                $now,
+                $profile['raw'],
+            ));
+            $updated++;
+        }
+
+        $missed = count($vkIds) - $updated;
+        if ($missed > 0) {
+            $this->logger->error('Some VK profiles were not returned', array('missed' => $missed));
+        }
+
+        return array('updated' => $updated, 'missed' => $missed);
+    }
+}

--- a/backend/src/Etl/Extract.php
+++ b/backend/src/Etl/Extract.php
@@ -1,0 +1,204 @@
+<?php
+namespace PixelAnalytics\Etl;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Logger;
+use PixelAnalytics\Helpers\Date;
+
+class Extract
+{
+    /** @var Logger */
+    private $logger;
+
+    /** @var WatermarkStore */
+    private $watermarks;
+
+    public function __construct(Logger $logger, WatermarkStore $watermarks)
+    {
+        $this->logger = $logger;
+        $this->watermarks = $watermarks;
+    }
+
+    public function run()
+    {
+        $lastOrderId = $this->watermarks->get('orders_last_id', 0);
+        $this->logger->info('Starting ETL extract', array('lastOrderId' => $lastOrderId));
+
+        $prodDb = Db::production();
+        $anDb = Db::analytics();
+
+        $sqlOrders = 'SELECT * FROM orders WHERE id > ? ORDER BY id ASC LIMIT 1000';
+        $orders = Db::query($prodDb, $sqlOrders, array((int) $lastOrderId));
+
+        if (empty($orders)) {
+            $this->logger->info('No new orders to process');
+            return array('orders' => 0, 'order_items' => 0, 'users' => 0);
+        }
+
+        $maxId = $lastOrderId;
+        $ordersInserted = 0;
+        $itemsInserted = 0;
+        $usersInserted = 0;
+
+        foreach ($orders as $order) {
+            $maxId = max($maxId, $order['id']);
+            $this->stageOrder($anDb, $order);
+            $ordersInserted += $this->upsertOrder($anDb, $order);
+            $itemsInserted += $this->syncOrderItems($prodDb, $anDb, $order['id']);
+            $usersInserted += $this->upsertUser($prodDb, $anDb, $order['user_id']);
+        }
+
+        $this->watermarks->set('orders_last_id', $maxId);
+
+        $this->logger->info('ETL extract completed', array(
+            'orders' => $ordersInserted,
+            'order_items' => $itemsInserted,
+            'users' => $usersInserted,
+        ));
+
+        return array('orders' => $ordersInserted, 'order_items' => $itemsInserted, 'users' => $usersInserted);
+    }
+
+    private function upsertOrder($anDb, $order)
+    {
+        $dateSql = 'SELECT date_sk FROM dim_date WHERE date = ? LIMIT 1';
+        $date = substr($order['order_dt'], 0, 10);
+        $dateSkRows = Db::query($anDb, $dateSql, array($date));
+        $dateSk = !empty($dateSkRows) ? $dateSkRows[0]['date_sk'] : 0;
+
+        $sql = 'REPLACE INTO fact_orders (order_id, user_id, order_dt, date_sk, city_id, channel, payment_type, promo_applied, items_qty, sum_goods, delivery_fee, discount_amount, sum_total) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        Db::query($anDb, $sql, array(
+            $order['id'],
+            $order['user_id'],
+            $order['order_dt'],
+            $dateSk,
+            isset($order['city_id']) ? $order['city_id'] : null,
+            isset($order['channel']) ? $order['channel'] : null,
+            isset($order['payment_type']) ? $order['payment_type'] : null,
+            isset($order['promo_applied']) ? (int) $order['promo_applied'] : 0,
+            isset($order['items_qty']) ? $order['items_qty'] : 0,
+            isset($order['sum_goods']) ? $order['sum_goods'] : 0,
+            isset($order['delivery_fee']) ? $order['delivery_fee'] : 0,
+            isset($order['discount_amount']) ? $order['discount_amount'] : 0,
+            isset($order['sum_total']) ? $order['sum_total'] : 0,
+        ));
+
+        return 1;
+    }
+
+    private function stageOrder($anDb, $order)
+    {
+        $sql = 'REPLACE INTO stg_orders (id, user_id, order_dt, city_id, channel, payment_type, promo_applied, items_qty, sum_goods, delivery_fee, discount_amount, sum_total, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        Db::query($anDb, $sql, array(
+            $order['id'],
+            $order['user_id'],
+            $order['order_dt'],
+            isset($order['city_id']) ? $order['city_id'] : null,
+            isset($order['channel']) ? $order['channel'] : null,
+            isset($order['payment_type']) ? $order['payment_type'] : null,
+            isset($order['promo_applied']) ? (int) $order['promo_applied'] : 0,
+            isset($order['items_qty']) ? $order['items_qty'] : 0,
+            isset($order['sum_goods']) ? $order['sum_goods'] : 0,
+            isset($order['delivery_fee']) ? $order['delivery_fee'] : 0,
+            isset($order['discount_amount']) ? $order['discount_amount'] : 0,
+            isset($order['sum_total']) ? $order['sum_total'] : 0,
+            isset($order['updated_at']) ? $order['updated_at'] : $order['order_dt'],
+        ));
+    }
+
+    private function stageOrderItem($anDb, $item)
+    {
+        $sql = 'REPLACE INTO stg_order_items (order_id, product_id, qty, price, amount) VALUES (?, ?, ?, ?, ?)';
+        Db::query($anDb, $sql, array(
+            $item['order_id'],
+            $item['product_id'],
+            $item['qty'],
+            $item['price'],
+            $item['amount'],
+        ));
+    }
+
+    private function stageUser($anDb, $user)
+    {
+        $sql = 'REPLACE INTO stg_users (id, phone, vk_id, created_at, updated_at, do_not_profile) VALUES (?, ?, ?, ?, ?, ?)';
+        Db::query($anDb, $sql, array(
+            $user['id'],
+            isset($user['phone']) ? $user['phone'] : null,
+            isset($user['vk_id']) ? $user['vk_id'] : null,
+            isset($user['created_at']) ? $user['created_at'] : null,
+            isset($user['updated_at']) ? $user['updated_at'] : null,
+            isset($user['do_not_profile']) ? (int) $user['do_not_profile'] : 0,
+        ));
+    }
+
+    private function syncOrderItems($prodDb, $anDb, $orderId)
+    {
+        $itemsSql = 'SELECT * FROM order_items WHERE order_id = ?';
+        $items = Db::query($prodDb, $itemsSql, array($orderId));
+        if (empty($items)) {
+            return 0;
+        }
+
+        foreach ($items as $item) {
+            $this->stageOrderItem($anDb, $item);
+            $sql = 'REPLACE INTO fact_order_items (order_id, product_id, qty, price, amount) VALUES (?, ?, ?, ?, ?)';
+            Db::query($anDb, $sql, array(
+                $item['order_id'],
+                $item['product_id'],
+                $item['qty'],
+                $item['price'],
+                $item['amount'],
+            ));
+
+            $this->upsertProduct($anDb, $item);
+        }
+
+        return count($items);
+    }
+
+    private function upsertProduct($anDb, $item)
+    {
+        $sql = 'INSERT INTO dim_product (product_id, name, category, price_current, updated_at) VALUES (?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE name = VALUES(name), category = VALUES(category), price_current = VALUES(price_current), updated_at = VALUES(updated_at)';
+        $name = isset($item['product_name']) ? $item['product_name'] : 'Unknown';
+        $category = isset($item['category']) ? $item['category'] : null;
+        $price = isset($item['price']) ? $item['price'] : 0;
+        $now = Date::formatSql(Date::now());
+        Db::query($anDb, $sql, array(
+            $item['product_id'],
+            $name,
+            $category,
+            $price,
+            $now,
+        ));
+    }
+
+    private function upsertUser($prodDb, $anDb, $userId)
+    {
+        $userSql = 'SELECT * FROM users WHERE id = ? LIMIT 1';
+        $rows = Db::query($prodDb, $userSql, array($userId));
+        if (empty($rows)) {
+            return 0;
+        }
+        $user = $rows[0];
+        $this->stageUser($anDb, $user);
+        $hash = hash('sha256', isset($user['phone']) ? $user['phone'] : '');
+        $binaryHash = pack('H*', $hash);
+        $sql = 'INSERT INTO dim_user (user_id, phone_sha256, created_at, do_not_profile, first_order_dt, last_order_dt)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE phone_sha256 = VALUES(phone_sha256), do_not_profile = VALUES(do_not_profile), first_order_dt = LEAST(IFNULL(first_order_dt, VALUES(first_order_dt)), VALUES(first_order_dt)), last_order_dt = GREATEST(IFNULL(last_order_dt, VALUES(last_order_dt)), VALUES(last_order_dt))';
+        $createdAt = isset($user['created_at']) ? $user['created_at'] : Date::formatSql(Date::now());
+        $orderDt = isset($user['last_order_dt']) ? $user['last_order_dt'] : $createdAt;
+        Db::query($anDb, $sql, array(
+            $user['id'],
+            $binaryHash,
+            $createdAt,
+            isset($user['do_not_profile']) ? (int) $user['do_not_profile'] : 0,
+            $orderDt,
+            $orderDt,
+        ));
+
+        return 1;
+    }
+}

--- a/backend/src/Etl/VkClient.php
+++ b/backend/src/Etl/VkClient.php
@@ -1,0 +1,116 @@
+<?php
+namespace PixelAnalytics\Etl;
+
+use Exception;
+use PixelAnalytics\Config;
+use PixelAnalytics\Helpers\Logger;
+
+class VkClient
+{
+    private $logger;
+    private $accessToken;
+    private $version;
+    private $batchSize;
+
+    public function __construct(Logger $logger)
+    {
+        $this->logger = $logger;
+        $vkConfig = Config::get('vk');
+        $this->accessToken = $vkConfig['access_token'];
+        $this->version = $vkConfig['api_version'];
+        $this->batchSize = $vkConfig['batch_size'];
+    }
+
+    public function fetchProfiles(array $vkIds)
+    {
+        $result = array();
+        $chunks = array_chunk($vkIds, $this->batchSize);
+        foreach ($chunks as $chunk) {
+            $profiles = $this->fetchChunk($chunk);
+            foreach ($profiles as $profile) {
+                $result[] = $profile;
+            }
+            usleep(rand(350000, 500000));
+        }
+        return $result;
+    }
+
+    private function fetchChunk(array $chunk)
+    {
+        $attempts = 0;
+        while ($attempts < 5) {
+            $attempts++;
+            $query = http_build_query(array(
+                'user_ids' => implode(',', $chunk),
+                'fields' => implode(',', array(
+                    'sex', 'bdate', 'city', 'country', 'occupation', 'education', 'relation', 'last_seen', 'is_closed'
+                )),
+                'access_token' => $this->accessToken,
+                'v' => $this->version,
+            ));
+            $url = 'https://api.vk.com/method/users.get?' . $query;
+            $response = $this->httpGet($url);
+            if (!isset($response['response'])) {
+                if (isset($response['error'])) {
+                    $error = $response['error'];
+                    $this->logger->error('VK API error', $error);
+                    if ((int) $error['error_code'] === 6) {
+                        sleep(1);
+                        continue;
+                    }
+                    throw new Exception('VK API error: ' . $error['error_msg']);
+                }
+                throw new Exception('VK API unexpected response');
+            }
+
+            $profiles = array();
+            foreach ($response['response'] as $row) {
+                $profiles[] = array(
+                    'vk_id' => $row['id'],
+                    'sex' => isset($row['sex']) ? (int) $row['sex'] : null,
+                    'age' => $this->extractAge($row),
+                    'city' => isset($row['city']['title']) ? $row['city']['title'] : null,
+                    'occupation' => isset($row['occupation']['name']) ? $row['occupation']['name'] : null,
+                    'is_closed' => isset($row['is_closed']) ? (int) $row['is_closed'] : null,
+                    'last_seen' => isset($row['last_seen']['time']) ? date('Y-m-d H:i:s', $row['last_seen']['time']) : null,
+                    'raw' => json_encode($row),
+                );
+            }
+            return $profiles;
+        }
+
+        throw new Exception('Unable to fetch VK profiles after retries');
+    }
+
+    private function httpGet($url)
+    {
+        $context = stream_context_create(array(
+            'http' => array(
+                'method' => 'GET',
+                'timeout' => 10,
+            ),
+        ));
+        $body = file_get_contents($url, false, $context);
+        if ($body === false) {
+            throw new Exception('Failed to call VK API');
+        }
+        return json_decode($body, true);
+    }
+
+    private function extractAge($row)
+    {
+        if (empty($row['bdate'])) {
+            return null;
+        }
+        $parts = explode('.', $row['bdate']);
+        if (count($parts) !== 3) {
+            return null;
+        }
+        $year = (int) $parts[2];
+        if ($year <= 0) {
+            return null;
+        }
+        $age = (int) date('Y') - $year;
+        return $age > 0 ? $age : null;
+    }
+}

--- a/backend/src/Etl/WatermarkStore.php
+++ b/backend/src/Etl/WatermarkStore.php
@@ -1,0 +1,27 @@
+<?php
+namespace PixelAnalytics\Etl;
+
+use PixelAnalytics\Db;
+use PixelAnalytics\Helpers\Date;
+
+class WatermarkStore
+{
+    public function get($name, $default = null)
+    {
+        $db = Db::analytics();
+        $sql = 'SELECT value_str FROM etl_watermarks WHERE name = ?';
+        $rows = Db::query($db, $sql, array($name));
+        if (is_array($rows) && !empty($rows)) {
+            return $rows[0]['value_str'];
+        }
+        return $default;
+    }
+
+    public function set($name, $value)
+    {
+        $db = Db::analytics();
+        $sql = 'REPLACE INTO etl_watermarks (name, value_str, updated_at) VALUES (?, ?, ?)';
+        $now = Date::formatSql(Date::now());
+        Db::query($db, $sql, array($name, $value, $now));
+    }
+}

--- a/backend/src/Helpers/Cache.php
+++ b/backend/src/Helpers/Cache.php
@@ -1,0 +1,35 @@
+<?php
+namespace PixelAnalytics\Helpers;
+
+class Cache
+{
+    private $path;
+
+    public function __construct($path)
+    {
+        $this->path = rtrim($path, '/');
+        if (!is_dir($this->path)) {
+            mkdir($this->path, 0775, true);
+        }
+    }
+
+    public function remember($key, $ttl, $callback)
+    {
+        $file = $this->path . '/' . md5($key) . '.json';
+        $now = time();
+        if (file_exists($file)) {
+            $data = json_decode(file_get_contents($file), true);
+            if (is_array($data) && isset($data['expires_at']) && $data['expires_at'] > $now) {
+                return $data['payload'];
+            }
+        }
+
+        $payload = call_user_func($callback);
+        $data = array(
+            'expires_at' => $now + $ttl,
+            'payload' => $payload,
+        );
+        file_put_contents($file, json_encode($data));
+        return $payload;
+    }
+}

--- a/backend/src/Helpers/Date.php
+++ b/backend/src/Helpers/Date.php
@@ -1,0 +1,20 @@
+<?php
+namespace PixelAnalytics\Helpers;
+
+class Date
+{
+    public static function now()
+    {
+        return new \DateTime('now');
+    }
+
+    public static function parse($dateString)
+    {
+        return new \DateTime($dateString);
+    }
+
+    public static function formatSql(\DateTime $dateTime)
+    {
+        return $dateTime->format('Y-m-d H:i:s');
+    }
+}

--- a/backend/src/Helpers/Env.php
+++ b/backend/src/Helpers/Env.php
@@ -1,0 +1,56 @@
+<?php
+namespace PixelAnalytics\Helpers;
+
+class Env
+{
+    /** @var array */
+    private static $values = array();
+
+    public static function bootstrap($file)
+    {
+        if (!empty(self::$values)) {
+            return;
+        }
+
+        $path = $file;
+        if (!file_exists($path)) {
+            $path = dirname(__DIR__) . '/../.env';
+            if (!file_exists($path)) {
+                return;
+            }
+        }
+
+        $lines = file($path);
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || strpos($line, '#') === 0) {
+                continue;
+            }
+            $parts = explode('=', $line, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            $key = trim($parts[0]);
+            $value = trim($parts[1]);
+            $value = trim($value, "\"'");
+            self::$values[$key] = $value;
+            if (!getenv($key)) {
+                putenv($key . '=' . $value);
+            }
+        }
+    }
+
+    public static function get($key, $default = null)
+    {
+        if (isset(self::$values[$key])) {
+            return self::$values[$key];
+        }
+
+        $value = getenv($key);
+        if ($value !== false) {
+            return $value;
+        }
+
+        return $default;
+    }
+}

--- a/backend/src/Helpers/Json.php
+++ b/backend/src/Helpers/Json.php
@@ -1,0 +1,27 @@
+<?php
+namespace PixelAnalytics\Helpers;
+
+class Json
+{
+    public static function success($data = array(), $status = 200)
+    {
+        return array(
+            'status' => $status,
+            'body' => array(
+                'status' => 'ok',
+                'data' => $data,
+            ),
+        );
+    }
+
+    public static function error($message, $status = 500)
+    {
+        return array(
+            'status' => $status,
+            'body' => array(
+                'status' => 'error',
+                'message' => $message,
+            ),
+        );
+    }
+}

--- a/backend/src/Helpers/Logger.php
+++ b/backend/src/Helpers/Logger.php
@@ -1,0 +1,38 @@
+<?php
+namespace PixelAnalytics\Helpers;
+
+class Logger
+{
+    private $file;
+
+    public function __construct($file)
+    {
+        $this->file = $file;
+        $dir = dirname($file);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+    }
+
+    public function info($message, $context = array())
+    {
+        $this->write('INFO', $message, $context);
+    }
+
+    public function error($message, $context = array())
+    {
+        $this->write('ERROR', $message, $context);
+    }
+
+    private function write($level, $message, $context)
+    {
+        $entry = sprintf(
+            "[%s] %s %s %s\n",
+            date('c'),
+            $level,
+            $message,
+            json_encode($context)
+        );
+        file_put_contents($this->file, $entry, FILE_APPEND);
+    }
+}

--- a/backend/src/Helpers/RateLimiter.php
+++ b/backend/src/Helpers/RateLimiter.php
@@ -1,0 +1,50 @@
+<?php
+namespace PixelAnalytics\Helpers;
+
+class RateLimiter
+{
+    private $key;
+    private $limit;
+    private $window;
+    private $storagePath;
+
+    public function __construct($key, $limit, $windowSeconds, $storagePath)
+    {
+        $this->key = preg_replace('/[^a-zA-Z0-9_-]/', '_', $key);
+        $this->limit = (int) $limit;
+        $this->window = (int) $windowSeconds;
+        $this->storagePath = rtrim($storagePath, '/');
+
+        if (!is_dir($this->storagePath)) {
+            mkdir($this->storagePath, 0775, true);
+        }
+    }
+
+    public function allow()
+    {
+        $file = $this->storagePath . '/' . $this->key . '.json';
+        $now = time();
+        $counter = array('count' => 0, 'expires_at' => $now + $this->window);
+
+        if (file_exists($file)) {
+            $content = file_get_contents($file);
+            $decoded = json_decode($content, true);
+            if (is_array($decoded) && isset($decoded['expires_at']) && $decoded['expires_at'] > $now) {
+                $counter = $decoded;
+            }
+        }
+
+        if ($counter['expires_at'] <= $now) {
+            $counter['count'] = 0;
+            $counter['expires_at'] = $now + $this->window;
+        }
+
+        if ($counter['count'] >= $this->limit) {
+            return false;
+        }
+
+        $counter['count']++;
+        file_put_contents($file, json_encode($counter));
+        return true;
+    }
+}

--- a/cli/etl_build_summaries.php
+++ b/cli/etl_build_summaries.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../backend/vendor/autoload.php';
+
+use PixelAnalytics\Config;
+use PixelAnalytics\Etl\BuildSummaries;
+use PixelAnalytics\Helpers\Logger;
+
+Config::init();
+
+$logFile = __DIR__ . '/../scripts/logs/etl_build_summaries.log';
+$logger = new Logger($logFile);
+$builder = new BuildSummaries($logger);
+
+try {
+    $builder->run();
+    echo "Summaries rebuilt\n";
+    exit(0);
+} catch (Exception $e) {
+    $logger->error('Build summaries failed', array('error' => $e->getMessage()));
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/cli/etl_extract.php
+++ b/cli/etl_extract.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../backend/vendor/autoload.php';
+
+use PixelAnalytics\Config;
+use PixelAnalytics\Etl\Extract;
+use PixelAnalytics\Etl\WatermarkStore;
+use PixelAnalytics\Helpers\Logger;
+
+Config::init();
+
+$logFile = __DIR__ . '/../scripts/logs/etl_extract.log';
+$logger = new Logger($logFile);
+$watermarks = new WatermarkStore();
+$extract = new Extract($logger, $watermarks);
+
+try {
+    $result = $extract->run();
+    echo sprintf("Orders: %d, Items: %d, Users: %d\n", $result['orders'], $result['order_items'], $result['users']);
+    exit(0);
+} catch (Exception $e) {
+    $logger->error('ETL extract failed', array('error' => $e->getMessage()));
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/cli/etl_vk_update.php
+++ b/cli/etl_vk_update.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/../backend/vendor/autoload.php';
+
+use PixelAnalytics\Config;
+use PixelAnalytics\Etl\EnrichVk;
+use PixelAnalytics\Etl\VkClient;
+use PixelAnalytics\Helpers\Logger;
+
+Config::init();
+
+$logFile = __DIR__ . '/../scripts/logs/etl_vk_update.log';
+$logger = new Logger($logFile);
+$client = new VkClient($logger);
+$enrich = new EnrichVk($logger, $client);
+
+try {
+    $candidates = $enrich->findPendingUsers(500);
+    $result = $enrich->updateProfiles($candidates);
+    echo sprintf("Updated: %d, Missed: %d\n", $result['updated'], $result['missed']);
+    exit(0);
+} catch (Exception $e) {
+    $logger->error('VK update failed', array('error' => $e->getMessage()));
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PixelAnalytics</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pixel-analytics-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "chart.js": "^4.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-chartjs-2": "^5.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.3",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { getKpi, getSegmentsCompare, getRfm, getProductsDaily, getCohorts } from './api.js';
+import KpiCards from './components/KpiCards.jsx';
+import SegmentsCompare from './components/SegmentsCompare.jsx';
+import RfmHeatmap from './components/RfmHeatmap.jsx';
+import ProductsTrend from './components/ProductsTrend.jsx';
+import CohortsChart from './components/CohortsChart.jsx';
+
+const defaultRange = {
+  from: new Date(Date.now() - 29 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+  to: new Date().toISOString().slice(0, 10)
+};
+
+export default function App() {
+  const [kpi, setKpi] = useState(null);
+  const [segments, setSegments] = useState(null);
+  const [rfm, setRfm] = useState(null);
+  const [products, setProducts] = useState(null);
+  const [cohorts, setCohorts] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [kpiData, segmentsData, rfmData, productData, cohortsData] = await Promise.all([
+          getKpi('30d'),
+          getSegmentsCompare(2),
+          getRfm('r>=4&f>=3&m>=3', 25),
+          getProductsDaily(defaultRange),
+          getCohorts()
+        ]);
+        setKpi(kpiData);
+        setSegments(segmentsData);
+        setRfm(rfmData);
+        setProducts(productData);
+        setCohorts(cohortsData);
+      } catch (err) {
+        console.error(err);
+        setError('Не удалось загрузить данные. Проверьте доступность API.');
+      }
+    }
+    load();
+  }, []);
+
+  if (error) {
+    return <div className="app-container">{error}</div>;
+  }
+
+  if (!kpi || !segments || !rfm || !products || !cohorts) {
+    return <div className="app-container">Загрузка...</div>;
+  }
+
+  return (
+    <div className="app-container">
+      <h1>PixelAnalytics</h1>
+      <div className="grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
+        <div className="card">
+          <KpiCards data={kpi} />
+        </div>
+        <div className="card">
+          <SegmentsCompare data={segments} />
+        </div>
+        <div className="card">
+          <RfmHeatmap data={rfm} />
+        </div>
+        <div className="card" style={{ gridColumn: '1 / -1' }}>
+          <ProductsTrend data={products} />
+        </div>
+        <div className="card" style={{ gridColumn: '1 / -1' }}>
+          <CohortsChart data={cohorts} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: '/api'
+});
+
+export async function getHealth() {
+  const { data } = await client.get('/health');
+  return data.data;
+}
+
+export async function getKpi(period = '30d') {
+  const { data } = await client.get('/kpi', { params: { period } });
+  return data.data;
+}
+
+export async function getSegmentsCompare(periods = 2) {
+  const { data } = await client.get('/segments/compare', { params: { periods } });
+  return data.data;
+}
+
+export async function getRfm(filter = 'r>=4&f>=3&m>=3', limit = 25) {
+  const { data } = await client.get('/rfm', { params: { filter, limit } });
+  return data.data;
+}
+
+export async function getProductsDaily(range) {
+  const { from, to } = range;
+  const { data } = await client.get('/products/daily', { params: { from, to } });
+  return data.data;
+}
+
+export async function getCohorts() {
+  const { data } = await client.get('/cohorts');
+  return data.data;
+}

--- a/frontend/src/components/CohortsChart.jsx
+++ b/frontend/src/components/CohortsChart.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export default function CohortsChart({ data }) {
+  if (!data.items || data.items.length === 0) {
+    return (
+      <div>
+        <h2>Когорты</h2>
+        <p>Недостаточно данных.</p>
+      </div>
+    );
+  }
+
+  const months = ['m0', 'm1', 'm2', 'm3', 'm4', 'm5', 'm6'];
+
+  return (
+    <div>
+      <h2>Когортный анализ</h2>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={cellStyle}>Когорта</th>
+              {months.map((month) => (
+                <th key={month} style={cellStyle}>{month.toUpperCase()}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((row) => (
+              <tr key={row.cohort_month}>
+                <td style={cellStyle}>{row.cohort_month}</td>
+                {months.map((month) => (
+                  <td key={month} style={cellStyle}>{row[month]}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+const cellStyle = {
+  borderBottom: '1px solid #eee',
+  padding: '8px',
+  textAlign: 'center'
+};

--- a/frontend/src/components/KpiCards.jsx
+++ b/frontend/src/components/KpiCards.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default function KpiCards({ data }) {
+  const metrics = [
+    { label: 'Оборот', value: formatCurrency(data.revenue) },
+    { label: 'Заказы', value: data.orders.toLocaleString('ru-RU') },
+    { label: 'Средний чек', value: formatCurrency(data.avg_check) },
+    { label: 'Ретеншн', value: (data.retention * 100).toFixed(1) + '%' }
+  ];
+
+  return (
+    <div>
+      <h2>Ключевые показатели</h2>
+      <div style={{ display: 'grid', gap: '1rem' }}>
+        {metrics.map((metric) => (
+          <div key={metric.label}>
+            <div style={{ fontSize: '0.9rem', color: '#666' }}>{metric.label}</div>
+            <div style={{ fontSize: '1.6rem', fontWeight: 600 }}>{metric.value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    maximumFractionDigits: 0
+  }).format(value || 0);
+}

--- a/frontend/src/components/ProductsTrend.jsx
+++ b/frontend/src/components/ProductsTrend.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+export default function ProductsTrend({ data }) {
+  const labels = data.series.map((point) => point.date);
+  const revenue = data.series.map((point) => point.revenue_sum);
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Выручка',
+        data: revenue,
+        borderColor: '#2563eb',
+        backgroundColor: 'rgba(37, 99, 235, 0.3)',
+        tension: 0.3,
+        fill: true
+      }
+    ]
+  };
+
+  return (
+    <div>
+      <h2>Дневной тренд продаж</h2>
+      <Line data={chartData} options={{ responsive: true, plugins: { legend: { display: false } } }} />
+    </div>
+  );
+}

--- a/frontend/src/components/RfmHeatmap.jsx
+++ b/frontend/src/components/RfmHeatmap.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export default function RfmHeatmap({ data }) {
+  const matrix = buildMatrix(data.items || []);
+
+  return (
+    <div>
+      <h2>RFM тепловая карта</h2>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '4px' }}>
+        {matrix.map((row, rowIndex) =>
+          row.map((cell, colIndex) => (
+            <div
+              key={`${rowIndex}-${colIndex}`}
+              style={{
+                padding: '12px',
+                background: `rgba(37, 99, 235, ${cell.share})`,
+                color: cell.share > 0.5 ? '#fff' : '#111',
+                textAlign: 'center',
+                borderRadius: '6px'
+              }}
+            >
+              <div style={{ fontSize: '0.8rem' }}>R{5 - rowIndex} / F{colIndex + 1}</div>
+              <div style={{ fontSize: '1.1rem', fontWeight: 600 }}>{(cell.share * 100).toFixed(1)}%</div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function buildMatrix(items) {
+  const totals = Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => ({ value: 0, share: 0 })));
+  let totalValue = 0;
+  items.forEach((item) => {
+    const rIndex = Math.max(0, Math.min(4, 5 - item.r_class));
+    const fIndex = Math.max(0, Math.min(4, item.f_class - 1));
+    totals[rIndex][fIndex].value += item.monetary_90d;
+    totalValue += item.monetary_90d;
+  });
+  if (totalValue === 0) {
+    return totals;
+  }
+  return totals.map((row) =>
+    row.map((cell) => ({
+      value: cell.value,
+      share: cell.value / totalValue
+    }))
+  );
+}

--- a/frontend/src/components/SegmentsCompare.jsx
+++ b/frontend/src/components/SegmentsCompare.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+export default function SegmentsCompare({ data }) {
+  const labels = data.groups.map((group) => `${group.sex || 'N/A'} · ${group.age_bucket} · ${group.city}`);
+  const revenueCurrent = data.groups.map((group) => group.current.revenue);
+  const revenuePrevious = data.groups.map((group) => group.previous.revenue);
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Текущая неделя',
+        backgroundColor: '#2563eb',
+        data: revenueCurrent
+      },
+      {
+        label: 'Прошлая неделя',
+        backgroundColor: '#a5b4fc',
+        data: revenuePrevious
+      }
+    ]
+  };
+
+  return (
+    <div>
+      <h2>Сегменты: выручка WoW</h2>
+      <Bar data={chartData} options={{ responsive: true, plugins: { legend: { position: 'bottom' } } }} />
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,0 +1,33 @@
+:root {
+  font-family: 'Inter', sans-serif;
+  background-color: #f5f5f5;
+  color: #222;
+}
+
+body, html, #root {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+}
+
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+}
+
+.card h2 {
+  margin-top: 0;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/scripts/cron_examples.txt
+++ b/scripts/cron_examples.txt
@@ -1,0 +1,4 @@
+# Ночной цикл (время сервера)
+0 3 * * *  /usr/bin/php /var/www/pixel-analytics/cli/etl_extract.php >> /var/log/pixel-analytics/etl_extract.log 2>&1
+10 3 * * * /usr/bin/php /var/www/pixel-analytics/cli/etl_vk_update.php >> /var/log/pixel-analytics/etl_vk_update.log 2>&1
+30 3 * * * /usr/bin/php /var/www/pixel-analytics/cli/etl_build_summaries.php >> /var/log/pixel-analytics/etl_build_summaries.log 2>&1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v php >/dev/null 2>&1; then
+  echo "PHP не найден. Установите PHP 5.6+" >&2
+  exit 1
+fi
+
+PHP_VERSION=$(php -r 'echo PHP_VERSION;')
+echo "PHP version: ${PHP_VERSION}"
+
+if ! command -v mysql >/dev/null 2>&1; then
+  echo "mysql клиент не найден" >&2
+  exit 1
+fi
+
+echo "MySQL client version: $(mysql --version)"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js 16.x обязателен" >&2
+  exit 1
+fi
+
+echo "Node.js version: $(node --version)"
+
+echo "
+== Подготовка окружения =="
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "Файл .env создан из примера. Проверьте и обновите доступы."
+fi
+
+set -a
+source .env
+set +a
+
+if [ -z "${AN_DB_NAME:-}" ]; then
+  echo "Переменные подключения к аналитической БД не заданы" >&2
+  exit 1
+fi
+
+MYSQL_CMD=(mysql -h"${AN_DB_HOST}" -u"${AN_DB_USER}" "${AN_DB_NAME}" --default-character-set="${AN_DB_CHARSET:-utf8}")
+if [ -n "${AN_DB_PASS:-}" ]; then
+  MYSQL_CMD=(mysql -h"${AN_DB_HOST}" -u"${AN_DB_USER}" -p"${AN_DB_PASS}" "${AN_DB_NAME}" --default-character-set="${AN_DB_CHARSET:-utf8}")
+fi
+
+echo "Создаем базу данных ${AN_DB_NAME}"
+mysql -h"${AN_DB_HOST}" -u"${AN_DB_USER}" ${AN_DB_PASS:+-p"${AN_DB_PASS}"} -e "CREATE DATABASE IF NOT EXISTS \`${AN_DB_NAME}\` CHARACTER SET utf8 COLLATE utf8_general_ci;"
+
+echo "Применяем sql/*.sql"
+for file in sql/*.sql; do
+  echo " > ${file}"
+  "${MYSQL_CMD[@]}" < "${file}"
+done
+
+echo "Сборка фронтенда"
+(cd frontend && npm install && npm run build)
+
+echo "Готово."
+echo "Для запуска API: php -S 0.0.0.0:${HTTP_PORT:-8080} -t backend/public"
+echo "Настройте cron по образцу из scripts/cron_examples.txt"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f .env ]; then
+  echo "Файл .env не найден. Запустите install.sh" >&2
+  exit 1
+fi
+
+set -a
+source .env
+set +a
+
+if [ -z "${AN_DB_NAME:-}" ]; then
+  echo "Переменные подключения к аналитической БД не заданы" >&2
+  exit 1
+fi
+
+MYSQL_CMD=(mysql -h"${AN_DB_HOST}" -u"${AN_DB_USER}" "${AN_DB_NAME}" --default-character-set="${AN_DB_CHARSET:-utf8}")
+if [ -n "${AN_DB_PASS:-}" ]; then
+  MYSQL_CMD=(mysql -h"${AN_DB_HOST}" -u"${AN_DB_USER}" -p"${AN_DB_PASS}" "${AN_DB_NAME}" --default-character-set="${AN_DB_CHARSET:-utf8}")
+fi
+
+for file in sql/*.sql; do
+  echo "Применяем ${file}"
+  "${MYSQL_CMD[@]}" < "${file}"
+done

--- a/sql/01_analytics_schema.sql
+++ b/sql/01_analytics_schema.sql
@@ -1,0 +1,172 @@
+-- Analytics schema for PixelAnalytics
+SET NAMES utf8;
+SET time_zone = '+03:00';
+
+CREATE TABLE IF NOT EXISTS dim_user (
+  user_id BIGINT UNSIGNED NOT NULL,
+  phone_sha256 BINARY(32) NOT NULL,
+  created_at DATETIME NOT NULL,
+  do_not_profile TINYINT(1) NOT NULL DEFAULT 0,
+  first_order_dt DATETIME NULL,
+  last_order_dt DATETIME NULL,
+  PRIMARY KEY (user_id),
+  KEY idx_dim_user_last_order_dt (last_order_dt)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS dim_product (
+  product_id BIGINT UNSIGNED NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  category VARCHAR(128) DEFAULT NULL,
+  price_current DECIMAL(10,2) DEFAULT NULL,
+  description TEXT,
+  updated_at DATETIME NULL,
+  PRIMARY KEY (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS dim_date (
+  date_sk INT NOT NULL,
+  date DATE NOT NULL,
+  year SMALLINT NOT NULL,
+  month TINYINT NOT NULL,
+  week TINYINT NOT NULL,
+  dow TINYINT NOT NULL,
+  is_weekend TINYINT(1) NOT NULL DEFAULT 0,
+  is_holiday_ru TINYINT(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (date_sk),
+  UNIQUE KEY uniq_dim_date_date (date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS fact_orders (
+  order_id BIGINT UNSIGNED NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+  order_dt DATETIME NOT NULL,
+  date_sk INT NOT NULL,
+  city_id INT NULL,
+  channel VARCHAR(32) DEFAULT NULL,
+  payment_type VARCHAR(16) DEFAULT NULL,
+  promo_applied TINYINT(1) NOT NULL DEFAULT 0,
+  items_qty INT NOT NULL DEFAULT 0,
+  sum_goods DECIMAL(10,2) NOT NULL DEFAULT 0,
+  delivery_fee DECIMAL(10,2) NOT NULL DEFAULT 0,
+  discount_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+  sum_total DECIMAL(10,2) NOT NULL DEFAULT 0,
+  PRIMARY KEY (order_id),
+  KEY idx_fact_orders_user (user_id),
+  KEY idx_fact_orders_order_dt (order_dt),
+  KEY idx_fact_orders_date_sk (date_sk)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS fact_order_items (
+  order_id BIGINT UNSIGNED NOT NULL,
+  product_id BIGINT UNSIGNED NOT NULL,
+  qty INT NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  PRIMARY KEY (order_id, product_id),
+  KEY idx_fact_order_items_product (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS vk_profiles (
+  user_id BIGINT UNSIGNED NOT NULL,
+  vk_id BIGINT UNSIGNED NOT NULL,
+  sex TINYINT NULL,
+  age SMALLINT NULL,
+  city VARCHAR(128) NULL,
+  occupation VARCHAR(128) NULL,
+  is_closed TINYINT(1) NULL,
+  last_seen DATETIME NULL,
+  fetched_at DATETIME NOT NULL,
+  raw_json MEDIUMTEXT NOT NULL,
+  PRIMARY KEY (user_id),
+  UNIQUE KEY uniq_vk_profiles_vk_id (vk_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS stg_users (
+  id BIGINT UNSIGNED NOT NULL,
+  phone VARBINARY(255) NULL,
+  vk_id BIGINT UNSIGNED NULL,
+  created_at DATETIME NULL,
+  updated_at DATETIME NULL,
+  do_not_profile TINYINT(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS stg_orders (
+  id BIGINT UNSIGNED NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+  order_dt DATETIME NOT NULL,
+  city_id INT NULL,
+  channel VARCHAR(32) NULL,
+  payment_type VARCHAR(16) NULL,
+  promo_applied TINYINT(1) NOT NULL DEFAULT 0,
+  items_qty INT NOT NULL DEFAULT 0,
+  sum_goods DECIMAL(10,2) NOT NULL DEFAULT 0,
+  delivery_fee DECIMAL(10,2) NOT NULL DEFAULT 0,
+  discount_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+  sum_total DECIMAL(10,2) NOT NULL DEFAULT 0,
+  updated_at DATETIME NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS stg_order_items (
+  order_id BIGINT UNSIGNED NOT NULL,
+  product_id BIGINT UNSIGNED NOT NULL,
+  qty INT NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  PRIMARY KEY (order_id, product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS summary_rfm (
+  user_id BIGINT UNSIGNED NOT NULL,
+  recency_days INT NOT NULL,
+  frequency_90d INT NOT NULL,
+  monetary_90d DECIMAL(10,2) NOT NULL,
+  r_class TINYINT NOT NULL,
+  f_class TINYINT NOT NULL,
+  m_class TINYINT NOT NULL,
+  segment_label VARCHAR(32) NOT NULL,
+  PRIMARY KEY (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS summary_segments_daily (
+  stat_date DATE NOT NULL,
+  sex TINYINT NULL,
+  age_bucket VARCHAR(11) NOT NULL,
+  city VARCHAR(128) NOT NULL,
+  users_cnt INT NOT NULL DEFAULT 0,
+  orders_cnt INT NOT NULL DEFAULT 0,
+  revenue_sum DECIMAL(12,2) NOT NULL DEFAULT 0,
+  avg_check DECIMAL(10,2) NOT NULL DEFAULT 0,
+  repeat_rate_90d DECIMAL(5,3) NOT NULL DEFAULT 0,
+  PRIMARY KEY (stat_date, sex, age_bucket, city)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS summary_products_daily (
+  date DATE NOT NULL,
+  product_id BIGINT UNSIGNED NOT NULL,
+  orders_cnt INT NOT NULL DEFAULT 0,
+  qty_sum INT NOT NULL DEFAULT 0,
+  revenue_sum DECIMAL(12,2) NOT NULL DEFAULT 0,
+  unique_buyers INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (date, product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS summary_cohorts (
+  cohort_month DATE NOT NULL,
+  m0 INT NOT NULL DEFAULT 0,
+  m1 INT NOT NULL DEFAULT 0,
+  m2 INT NOT NULL DEFAULT 0,
+  m3 INT NOT NULL DEFAULT 0,
+  m4 INT NOT NULL DEFAULT 0,
+  m5 INT NOT NULL DEFAULT 0,
+  m6 INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (cohort_month)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS etl_watermarks (
+  name VARCHAR(64) NOT NULL,
+  value_str VARCHAR(64) NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/02_seed_dim_date.sql
+++ b/sql/02_seed_dim_date.sql
@@ -1,0 +1,36 @@
+-- Populate dim_date with a rolling five year calendar
+SET @start_date = DATE_SUB(CURDATE(), INTERVAL 365 DAY);
+SET @end_date = DATE_ADD(CURDATE(), INTERVAL 5 YEAR);
+SET @days = DATEDIFF(@end_date, @start_date) + 1;
+
+DELETE FROM dim_date;
+
+INSERT INTO dim_date (
+  date_sk,
+  date,
+  year,
+  month,
+  week,
+  dow,
+  is_weekend,
+  is_holiday_ru
+)
+SELECT
+  seq.seq_id AS date_sk,
+  DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY) AS date,
+  YEAR(DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY)) AS year,
+  MONTH(DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY)) AS month,
+  WEEK(DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY), 1) AS week,
+  DAYOFWEEK(DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY)) AS dow,
+  IF(DAYOFWEEK(DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY)) IN (1,7), 1, 0) AS is_weekend,
+  IF(DATE_FORMAT(DATE_ADD(@start_date, INTERVAL seq.seq_id - 1 DAY), '%m-%d') IN ('01-01','01-07','02-23','03-08','05-01','05-09','06-12','11-04'), 1, 0) AS is_holiday_ru
+FROM (
+  SELECT @row := @row + 1 AS seq_id
+  FROM
+    (SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0) t1,
+    (SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0) t2,
+    (SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0) t3,
+    (SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0 UNION ALL SELECT 0) t4,
+    (SELECT @row := 0) init
+  LIMIT @days
+) AS seq;

--- a/sql/03_indexes.sql
+++ b/sql/03_indexes.sql
@@ -1,0 +1,22 @@
+-- Additional indexes for analytics workload
+ALTER TABLE fact_orders
+  ADD KEY idx_fact_orders_channel (channel),
+  ADD KEY idx_fact_orders_payment_type (payment_type);
+
+ALTER TABLE fact_order_items
+  ADD KEY idx_fact_order_items_order (order_id);
+
+ALTER TABLE vk_profiles
+  ADD KEY idx_vk_profiles_fetched_at (fetched_at);
+
+ALTER TABLE summary_rfm
+  ADD KEY idx_summary_rfm_segment (segment_label);
+
+ALTER TABLE summary_segments_daily
+  ADD KEY idx_summary_segments_daily_city (city);
+
+ALTER TABLE summary_products_daily
+  ADD KEY idx_summary_products_daily_product (product_id);
+
+ALTER TABLE summary_cohorts
+  ADD KEY idx_summary_cohorts_month (cohort_month);


### PR DESCRIPTION
## Summary
- add SQL schema, seeds, and index definitions for the analytics warehouse
- implement PHP ETL workflows, cached API controllers, and CLI entrypoints
- scaffold a React SPA dashboard and provisioning scripts for install and cron setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdd0e35518832b9c2cf20ec144abaf