### PR TITLE
Add status filtering and charts to dashboard summary

### DIFF
--- a/public/index13.php
+++ b/public/index13.php
@@ -29,7 +29,7 @@ $statusLabels = [
     1 => 'Оплачен',
     6 => 'Перебит',
     3 => 'Отменён',
-    0 => 'Черновик',
+    0 => 'Не оплачен',
 ];
 
 if ($availableStatuses === []) {
@@ -42,30 +42,37 @@ foreach ($availableStatuses as $statusValue) {
     $statusOptions[$statusInt] = $statusLabels[$statusInt] ?? ('Статус #' . $statusInt);
 }
 
-$defaultStatuses = array_values(array_intersect([1, 6], array_keys($statusOptions)));
-if ($defaultStatuses === []) {
-    $defaultStatuses = array_keys($statusOptions);
+$preferredDefaults = [1, 6];
+$defaultStatus = null;
+foreach ($preferredDefaults as $preferred) {
+    if (array_key_exists($preferred, $statusOptions)) {
+        $defaultStatus = $preferred;
+        break;
+    }
+}
+if ($defaultStatus === null) {
+    $defaultStatus = array_key_first($statusOptions);
 }
 
-$statusParam = $_GET['status'] ?? $defaultStatuses;
-if (!is_array($statusParam)) {
-    $statusParam = [$statusParam];
+$statusParam = $_GET['status'] ?? $defaultStatus;
+if (is_array($statusParam)) {
+    $statusParam = reset($statusParam);
 }
 
-$selectedStatuses = [];
-foreach ($statusParam as $statusValue) {
-    if (is_numeric($statusValue)) {
-        $statusInt = (int) $statusValue;
-        if (array_key_exists($statusInt, $statusOptions)) {
-            $selectedStatuses[] = $statusInt;
+$selectedStatus = $defaultStatus;
+if ($statusParam !== null && $statusParam !== '') {
+    if (is_numeric($statusParam)) {
+        $candidate = (int) $statusParam;
+        if (array_key_exists($candidate, $statusOptions)) {
+            $selectedStatus = $candidate;
         }
     }
 }
-$selectedStatuses = array_values(array_unique($selectedStatuses));
-if ($selectedStatuses === []) {
-    $selectedStatuses = $defaultStatuses;
+
+$selectedStatuses = $selectedStatus !== null ? [$selectedStatus] : [];
+if ($selectedStatuses !== []) {
+    sort($selectedStatuses);
 }
-sort($selectedStatuses);
 
 $cityMap = $dashboardService->getCityMap($selectedStatuses);
 

--- a/public/templates/index13.phtml
+++ b/public/templates/index13.phtml
@@ -30,7 +30,6 @@ $positiveDeltaIsGood = $selectedStatusValue !== 3;
 $selectedStatusStats = $selectedStatusValue !== null
     ? ($statusStats[$selectedStatusValue] ?? ['total_orders' => 0, 'total_revenue' => 0.0])
     : ['total_orders' => 0, 'total_revenue' => 0.0];
-$statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
 ?>
 <!doctype html>
 <html lang="ru">
@@ -47,8 +46,6 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
         .product-card { border:1px solid #ddd; border-radius:6px; padding:3px 10px; margin:3px 0; background:#fafafa; }
         .product-title { font-weight:500; }
         .product-meta { font-size:0.85em; color:#666; }
-        .summary-chart { position: relative; height: 120px; }
-        .summary-chart canvas { max-height: 120px; }
         .status-select-group { gap: 0.75rem; }
         .status-select-group .form-check { align-items: flex-start; }
         .status-select-group .status-meta { display:block; font-size:0.78rem; color:#6c757d; }
@@ -95,22 +92,15 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
     </form>
 
     <?php if ($selectedStatusValue !== null): ?>
-        <div class="mb-4">
-            <div class="d-flex flex-wrap align-items-center gap-2">
-                <span class="text-muted small">Выбран статус:</span>
-                <span class="badge bg-secondary">
-                    <?=htmlspecialchars($statusOptions[$selectedStatusValue] ?? ('Статус #' . $selectedStatusValue))?>
-                </span>
-                <span class="text-muted small">
-                    <?=number_format((int) ($selectedStatusStats['total_orders'] ?? 0), 0, ',', ' ')?> заказов ·
-                    <?=number_format((float) ($selectedStatusStats['total_revenue'] ?? 0), 0, ',', ' ')?> ₽
-                </span>
-            </div>
-            <?php if (!$statusHasData): ?>
-                <div class="alert alert-warning mt-3 mb-0">
-                    За выбранный период нет заказов с таким статусом. Попробуйте выбрать другой статус, чтобы увидеть сегменты и диаграммы.
-                </div>
-            <?php endif; ?>
+        <div class="mb-4 d-flex flex-wrap align-items-center gap-2">
+            <span class="text-muted small">Выбран статус:</span>
+            <span class="badge bg-secondary">
+                <?=htmlspecialchars($statusOptions[$selectedStatusValue] ?? ('Статус #' . $selectedStatusValue))?>
+            </span>
+            <span class="text-muted small">
+                <?=number_format((int) ($selectedStatusStats['total_orders'] ?? 0), 0, ',', ' ')?> заказов ·
+                <?=number_format((float) ($selectedStatusStats['total_revenue'] ?? 0), 0, ',', ' ')?> ₽
+            </span>
         </div>
     <?php endif; ?>
 
@@ -142,17 +132,9 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
             $currentValue = $totals[$key] ?? 0;
             $previousValue = $totalsPrev[$key] ?? 0;
             $delta = MarketingDashboardFormatter::calculateDelta($currentValue, $previousValue);
-            $summaryChartId = 'summary_' . $key;
-            $chartConfigs[] = [
-                'id' => $summaryChartId,
-                'current' => (float) $currentValue,
-                'previous' => (float) $previousValue,
-                'label' => $metric['label'],
-                'format' => $metric['format'],
-            ];
-            ?>
-            <div class="col">
-                <div class="card shadow-sm h-100">
+                    ?>
+                    <div class="col">
+                        <div class="card shadow-sm h-100">
                     <div class="card-body">
                         <h6><?=htmlspecialchars($metric['label'])?></h6>
                         <strong><?=$formatValue($currentValue, $metric['format'])?></strong>
@@ -162,9 +144,6 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
                             (<?=MarketingDashboardFormatter::formatDelta($delta)?>)
                         </div>
 
-                        <div class="summary-chart mt-3">
-                            <canvas id="<?=htmlspecialchars($summaryChartId)?>"></canvas>
-                        </div>
                     </div>
                 </div>
             </div>
@@ -174,9 +153,16 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
     <ul class="nav nav-tabs" id="segmentTabs" role="tablist">
         <?php $first = true; foreach ($allMetrics as $dim => $block): ?>
             <li class="nav-item" role="presentation">
-                <a class="nav-link <?=$first ? 'active' : ''?>" id="tab-<?=$dim?>" data-bs-toggle="tab" href="#pane-<?=$dim?>" role="tab" aria-controls="pane-<?=$dim?>" aria-selected="<?=$first ? 'true' : 'false'?>">
+                <button
+                    class="nav-link <?=$first ? 'active' : ''?>"
+                    id="tab-<?=$dim?>"
+                    data-bs-toggle="tab"
+                    data-bs-target="#pane-<?=$dim?>"
+                    type="button"
+                    role="tab"
+                >
                     <?=htmlspecialchars($dimensionList[$dim]['label'])?>
-                </a>
+                </button>
             </li>
             <?php $first = false; endforeach; ?>
     </ul>
@@ -199,13 +185,8 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
             ];
             ?>
             <div class="tab-pane fade <?=$first ? 'show active' : ''?>" id="pane-<?=$dim?>" role="tabpanel">
-                <?php if (empty($block['current'])): ?>
-                    <div class="alert alert-info">
-                        Нет данных по этому сегменту для выбранного статуса и периода.
-                    </div>
-                <?php else: ?>
-                    <div class="row g-3">
-                        <?php foreach ($block['current'] as $metricRow): ?>
+                <div class="row g-3">
+                    <?php foreach ($block['current'] as $metricRow): ?>
                         <?php
                         $value = $metricRow['dimension_value'];
                         $prev = $previousMap[$value] ?? $defaultPrev;
@@ -221,8 +202,6 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
                             'id' => $chartId,
                             'current' => (float) ($metricRow['total_revenue'] ?? 0),
                             'previous' => (float) ($prev['total_revenue'] ?? 0),
-                            'label' => 'Выручка',
-                            'format' => 'currency',
                         ];
                         ?>
                         <div class="col-lg-3 col-md-6">
@@ -329,9 +308,15 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
                                 </div>
                             </div>
                         </div>
-                        <?php endforeach; ?>
-                    </div>
-                <?php endif; ?>
+                    <?php endforeach; ?>
+                    <?php if (empty($block['current'])): ?>
+                        <div class="col-12">
+                            <div class="alert alert-info mb-0">
+                                Нет данных по этому сегменту для выбранного статуса и периода.
+                            </div>
+                        </div>
+                    <?php endif; ?>
+                </div>
             </div>
             <?php $first = false; endforeach; ?>
     </div>
@@ -339,56 +324,26 @@ $statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
     const chartConfigs = <?=json_encode($chartConfigs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)?>;
-    const formatters = {
-        currency: new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 }),
-        decimal: new Intl.NumberFormat('ru-RU', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-        number: new Intl.NumberFormat('ru-RU'),
-    };
-
     chartConfigs.forEach((config) => {
         const canvas = document.getElementById(config.id);
         if (!canvas) {
             return;
         }
 
-        const formatKey = config.format && formatters[config.format] ? config.format : 'number';
-        const formatter = formatters[formatKey];
-        const datasetLabel = config.label || 'Показатель';
-        const dataPoints = [Number(config.current) || 0, Number(config.previous) || 0];
-
         new Chart(canvas, {
-            type: config.type || 'bar',
+            type: 'bar',
             data: {
                 labels: ['Текущий', 'Предыдущий'],
                 datasets: [{
-                    label: datasetLabel,
-                    data: dataPoints,
+                    label: 'Выручка',
+                    data: [config.current, config.previous],
                     backgroundColor: ['rgba(54, 162, 235, 0.7)', 'rgba(200, 200, 200, 0.7)'],
-                    borderRadius: 6,
                 }],
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                        callbacks: {
-                            label: (context) => {
-                                const value = dataPoints[context.dataIndex] ?? 0;
-                                return `${context.dataset.label}: ${formatter.format(value)}`;
-                            },
-                        },
-                    },
-                },
-                scales: {
-                    y: {
-                        beginAtZero: true,
-                        ticks: {
-                            callback: (value) => formatter.format(Number(value) || 0),
-                        },
-                    },
-                },
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true } },
             },
         });
     });

--- a/public/templates/index13.phtml
+++ b/public/templates/index13.phtml
@@ -25,6 +25,8 @@ $summaryMetrics = [
 $chartConfigs = [];
 $currentPeriodDays = $start->diff($end)->days + 1;
 $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
+$selectedStatusValue = isset($selectedStatuses[0]) ? (int) $selectedStatuses[0] : null;
+$positiveDeltaIsGood = $selectedStatusValue !== 3;
 ?>
 <!doctype html>
 <html lang="ru">
@@ -60,34 +62,32 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
             <input type="date" class="form-control" name="end" value="<?=htmlspecialchars($end->format('Y-m-d'))?>">
         </div>
         <div class="col-md-4">
-            <label class="form-label d-block">Статусы заказов</label>
+            <label class="form-label d-block">Статус заказов</label>
             <div class="d-flex flex-wrap status-select-group">
                 <?php foreach ($statusOptions as $statusValue => $statusLabel): ?>
                     <?php $statusId = 'status-' . $statusValue; ?>
                     <div class="form-check form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="status[]" value="<?=htmlspecialchars((string) $statusValue)?>" id="<?=htmlspecialchars($statusId)?>" <?=in_array($statusValue, $selectedStatuses, true) ? 'checked' : ''?>>
+                        <input class="form-check-input" type="radio" name="status" value="<?=htmlspecialchars((string) $statusValue)?>" id="<?=htmlspecialchars($statusId)?>" <?=$selectedStatusValue === (int) $statusValue ? 'checked' : ''?>>
                         <label class="form-check-label" for="<?=htmlspecialchars($statusId)?>">
                             <?=htmlspecialchars($statusLabel)?>
                         </label>
                     </div>
                 <?php endforeach; ?>
             </div>
-            <div class="form-text">Показатели рассчитываются по выбранным статусам.</div>
+            <div class="form-text">Показатели рассчитываются по выбранному статусу.</div>
         </div>
         <div class="col-md-2 d-flex align-items-end">
             <button class="btn btn-primary w-100">Обновить</button>
         </div>
     </form>
 
-    <?php if (!empty($selectedStatuses)): ?>
+    <?php if ($selectedStatusValue !== null): ?>
         <div class="mb-4">
             <div class="d-flex flex-wrap align-items-center gap-2">
-                <span class="text-muted small">Выбраны статусы:</span>
-                <?php foreach ($selectedStatuses as $statusValue): ?>
-                    <span class="badge bg-secondary">
-                        <?=htmlspecialchars($statusOptions[$statusValue] ?? ('Статус #' . $statusValue))?>
-                    </span>
-                <?php endforeach; ?>
+                <span class="text-muted small">Выбран статус:</span>
+                <span class="badge bg-secondary">
+                    <?=htmlspecialchars($statusOptions[$selectedStatusValue] ?? ('Статус #' . $selectedStatusValue))?>
+                </span>
             </div>
         </div>
     <?php endif; ?>
@@ -135,7 +135,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                         <h6><?=htmlspecialchars($metric['label'])?></h6>
                         <strong><?=$formatValue($currentValue, $metric['format'])?></strong>
 
-                        <div class="small <?=MarketingDashboardFormatter::deltaClass($delta)?> mt-2">
+                        <div class="small <?=MarketingDashboardFormatter::deltaClass($delta, $positiveDeltaIsGood)?> mt-2">
                             Было: <?=$formatValue($previousValue, $metric['format'])?>
                             (<?=MarketingDashboardFormatter::formatDelta($delta)?>)
                         </div>
@@ -152,9 +152,9 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
     <ul class="nav nav-tabs" id="segmentTabs" role="tablist">
         <?php $first = true; foreach ($allMetrics as $dim => $block): ?>
             <li class="nav-item" role="presentation">
-                <button class="nav-link <?=$first ? 'active' : ''?>" id="tab-<?=$dim?>" data-bs-toggle="tab" data-bs-target="#pane-<?=$dim?>" type="button" role="tab">
+                <a class="nav-link <?=$first ? 'active' : ''?>" id="tab-<?=$dim?>" data-bs-toggle="tab" href="#pane-<?=$dim?>" role="tab" aria-controls="pane-<?=$dim?>" aria-selected="<?=$first ? 'true' : 'false'?>">
                     <?=htmlspecialchars($dimensionList[$dim]['label'])?>
-                </button>
+                </a>
             </li>
             <?php $first = false; endforeach; ?>
     </ul>
@@ -212,7 +212,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Выручка</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['total_revenue'] ?? 0), 0, ',', ' ')?> ₽<br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($revenueDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($revenueDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['total_revenue'] ?? 0), 0, ',', ' ')?> ₽
                                                     (<?=MarketingDashboardFormatter::formatDelta($revenueDelta)?>)
                                                 </small>
@@ -222,7 +222,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Заказы</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['total_orders'] ?? 0), 0, ',', ' ')?><br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($ordersDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($ordersDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['total_orders'] ?? 0), 0, ',', ' ')?>
                                                     (<?=MarketingDashboardFormatter::formatDelta($ordersDelta)?>)
                                                 </small>
@@ -232,7 +232,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Клиенты</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['total_customers'] ?? 0), 0, ',', ' ')?><br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($customersDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($customersDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['total_customers'] ?? 0), 0, ',', ' ')?>
                                                     (<?=MarketingDashboardFormatter::formatDelta($customersDelta)?>)
                                                 </small>
@@ -242,7 +242,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Средний чек</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['avg_receipt'] ?? 0), 0, ',', ' ')?> ₽<br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($avgReceiptDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($avgReceiptDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['avg_receipt'] ?? 0), 0, ',', ' ')?> ₽
                                                     (<?=MarketingDashboardFormatter::formatDelta($avgReceiptDelta)?>)
                                                 </small>
@@ -252,7 +252,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Новые клиенты</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['new_customers'] ?? 0), 0, ',', ' ')?><br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($newCustomersDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($newCustomersDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['new_customers'] ?? 0), 0, ',', ' ')?>
                                                     (<?=MarketingDashboardFormatter::formatDelta($newCustomersDelta)?>)
                                                 </small>
@@ -262,7 +262,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Повторные клиенты</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['repeat_customers'] ?? 0), 0, ',', ' ')?><br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($repeatCustomersDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($repeatCustomersDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['repeat_customers'] ?? 0), 0, ',', ' ')?>
                                                     (<?=MarketingDashboardFormatter::formatDelta($repeatCustomersDelta)?>)
                                                 </small>
@@ -272,7 +272,7 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                                             <th>Частота заказов</th>
                                             <td>
                                                 <?=number_format((float) ($metricRow['avg_frequency'] ?? 0), 2, ',', ' ')?><br>
-                                                <small class="<?=MarketingDashboardFormatter::deltaClass($frequencyDelta)?>">
+                                                <small class="<?=MarketingDashboardFormatter::deltaClass($frequencyDelta, $positiveDeltaIsGood)?>">
                                                     Было: <?=number_format((float) ($prev['avg_frequency'] ?? 0), 2, ',', ' ')?>
                                                     (<?=MarketingDashboardFormatter::formatDelta($frequencyDelta)?>)
                                                 </small>

--- a/public/templates/index13.phtml
+++ b/public/templates/index13.phtml
@@ -41,6 +41,9 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
         .product-card { border:1px solid #ddd; border-radius:6px; padding:3px 10px; margin:3px 0; background:#fafafa; }
         .product-title { font-weight:500; }
         .product-meta { font-size:0.85em; color:#666; }
+        .summary-chart { position: relative; height: 120px; }
+        .summary-chart canvas { max-height: 120px; }
+        .status-select-group { gap: 0.75rem; }
     </style>
 </head>
 <body class="bg-light p-3">
@@ -56,10 +59,38 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
             <label class="form-label">Конец</label>
             <input type="date" class="form-control" name="end" value="<?=htmlspecialchars($end->format('Y-m-d'))?>">
         </div>
-        <div class="col-md-3 d-flex align-items-end">
+        <div class="col-md-4">
+            <label class="form-label d-block">Статусы заказов</label>
+            <div class="d-flex flex-wrap status-select-group">
+                <?php foreach ($statusOptions as $statusValue => $statusLabel): ?>
+                    <?php $statusId = 'status-' . $statusValue; ?>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="status[]" value="<?=htmlspecialchars((string) $statusValue)?>" id="<?=htmlspecialchars($statusId)?>" <?=in_array($statusValue, $selectedStatuses, true) ? 'checked' : ''?>>
+                        <label class="form-check-label" for="<?=htmlspecialchars($statusId)?>">
+                            <?=htmlspecialchars($statusLabel)?>
+                        </label>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+            <div class="form-text">Показатели рассчитываются по выбранным статусам.</div>
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
             <button class="btn btn-primary w-100">Обновить</button>
         </div>
     </form>
+
+    <?php if (!empty($selectedStatuses)): ?>
+        <div class="mb-4">
+            <div class="d-flex flex-wrap align-items-center gap-2">
+                <span class="text-muted small">Выбраны статусы:</span>
+                <?php foreach ($selectedStatuses as $statusValue): ?>
+                    <span class="badge bg-secondary">
+                        <?=htmlspecialchars($statusOptions[$statusValue] ?? ('Статус #' . $statusValue))?>
+                    </span>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endif; ?>
 
     <div class="row row-cols-1 row-cols-md-2 g-3 mb-4">
         <div class="col">
@@ -89,6 +120,14 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
             $currentValue = $totals[$key] ?? 0;
             $previousValue = $totalsPrev[$key] ?? 0;
             $delta = MarketingDashboardFormatter::calculateDelta($currentValue, $previousValue);
+            $summaryChartId = 'summary_' . $key;
+            $chartConfigs[] = [
+                'id' => $summaryChartId,
+                'current' => (float) $currentValue,
+                'previous' => (float) $previousValue,
+                'label' => $metric['label'],
+                'format' => $metric['format'],
+            ];
             ?>
             <div class="col">
                 <div class="card shadow-sm h-100">
@@ -99,6 +138,10 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                         <div class="small <?=MarketingDashboardFormatter::deltaClass($delta)?> mt-2">
                             Было: <?=$formatValue($previousValue, $metric['format'])?>
                             (<?=MarketingDashboardFormatter::formatDelta($delta)?>)
+                        </div>
+
+                        <div class="summary-chart mt-3">
+                            <canvas id="<?=htmlspecialchars($summaryChartId)?>"></canvas>
                         </div>
                     </div>
                 </div>
@@ -151,6 +194,8 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
                             'id' => $chartId,
                             'current' => (float) ($metricRow['total_revenue'] ?? 0),
                             'previous' => (float) ($prev['total_revenue'] ?? 0),
+                            'label' => 'Выручка',
+                            'format' => 'currency',
                         ];
                         ?>
                         <div class="col-lg-3 col-md-6">
@@ -266,26 +311,56 @@ $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
     const chartConfigs = <?=json_encode($chartConfigs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)?>;
+    const formatters = {
+        currency: new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 }),
+        decimal: new Intl.NumberFormat('ru-RU', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+        number: new Intl.NumberFormat('ru-RU'),
+    };
+
     chartConfigs.forEach((config) => {
         const canvas = document.getElementById(config.id);
         if (!canvas) {
             return;
         }
 
+        const formatKey = config.format && formatters[config.format] ? config.format : 'number';
+        const formatter = formatters[formatKey];
+        const datasetLabel = config.label || 'Показатель';
+        const dataPoints = [Number(config.current) || 0, Number(config.previous) || 0];
+
         new Chart(canvas, {
-            type: 'bar',
+            type: config.type || 'bar',
             data: {
                 labels: ['Текущий', 'Предыдущий'],
                 datasets: [{
-                    label: 'Выручка',
-                    data: [config.current, config.previous],
+                    label: datasetLabel,
+                    data: dataPoints,
                     backgroundColor: ['rgba(54, 162, 235, 0.7)', 'rgba(200, 200, 200, 0.7)'],
+                    borderRadius: 6,
                 }],
             },
             options: {
                 responsive: true,
-                plugins: { legend: { display: false } },
-                scales: { y: { beginAtZero: true } },
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: (context) => {
+                                const value = dataPoints[context.dataIndex] ?? 0;
+                                return `${context.dataset.label}: ${formatter.format(value)}`;
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            callback: (value) => formatter.format(Number(value) || 0),
+                        },
+                    },
+                },
             },
         });
     });

--- a/public/templates/index13.phtml
+++ b/public/templates/index13.phtml
@@ -27,6 +27,10 @@ $currentPeriodDays = $start->diff($end)->days + 1;
 $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
 $selectedStatusValue = isset($selectedStatuses[0]) ? (int) $selectedStatuses[0] : null;
 $positiveDeltaIsGood = $selectedStatusValue !== 3;
+$selectedStatusStats = $selectedStatusValue !== null
+    ? ($statusStats[$selectedStatusValue] ?? ['total_orders' => 0, 'total_revenue' => 0.0])
+    : ['total_orders' => 0, 'total_revenue' => 0.0];
+$statusHasData = ($selectedStatusStats['total_orders'] ?? 0) > 0;
 ?>
 <!doctype html>
 <html lang="ru">
@@ -46,6 +50,8 @@ $positiveDeltaIsGood = $selectedStatusValue !== 3;
         .summary-chart { position: relative; height: 120px; }
         .summary-chart canvas { max-height: 120px; }
         .status-select-group { gap: 0.75rem; }
+        .status-select-group .form-check { align-items: flex-start; }
+        .status-select-group .status-meta { display:block; font-size:0.78rem; color:#6c757d; }
     </style>
 </head>
 <body class="bg-light p-3">
@@ -65,11 +71,18 @@ $positiveDeltaIsGood = $selectedStatusValue !== 3;
             <label class="form-label d-block">Статус заказов</label>
             <div class="d-flex flex-wrap status-select-group">
                 <?php foreach ($statusOptions as $statusValue => $statusLabel): ?>
-                    <?php $statusId = 'status-' . $statusValue; ?>
+                    <?php
+                    $statusId = 'status-' . $statusValue;
+                    $stats = $statusStats[$statusValue] ?? ['total_orders' => 0, 'total_revenue' => 0.0];
+                    ?>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="status" value="<?=htmlspecialchars((string) $statusValue)?>" id="<?=htmlspecialchars($statusId)?>" <?=$selectedStatusValue === (int) $statusValue ? 'checked' : ''?>>
                         <label class="form-check-label" for="<?=htmlspecialchars($statusId)?>">
-                            <?=htmlspecialchars($statusLabel)?>
+                            <span><?=htmlspecialchars($statusLabel)?></span>
+                            <span class="status-meta">
+                                <?=number_format((float) ($stats['total_revenue'] ?? 0), 0, ',', ' ')?> ₽ ·
+                                <?=number_format((int) ($stats['total_orders'] ?? 0), 0, ',', ' ')?> заказов
+                            </span>
                         </label>
                     </div>
                 <?php endforeach; ?>
@@ -88,7 +101,16 @@ $positiveDeltaIsGood = $selectedStatusValue !== 3;
                 <span class="badge bg-secondary">
                     <?=htmlspecialchars($statusOptions[$selectedStatusValue] ?? ('Статус #' . $selectedStatusValue))?>
                 </span>
+                <span class="text-muted small">
+                    <?=number_format((int) ($selectedStatusStats['total_orders'] ?? 0), 0, ',', ' ')?> заказов ·
+                    <?=number_format((float) ($selectedStatusStats['total_revenue'] ?? 0), 0, ',', ' ')?> ₽
+                </span>
             </div>
+            <?php if (!$statusHasData): ?>
+                <div class="alert alert-warning mt-3 mb-0">
+                    За выбранный период нет заказов с таким статусом. Попробуйте выбрать другой статус, чтобы увидеть сегменты и диаграммы.
+                </div>
+            <?php endif; ?>
         </div>
     <?php endif; ?>
 
@@ -177,8 +199,13 @@ $positiveDeltaIsGood = $selectedStatusValue !== 3;
             ];
             ?>
             <div class="tab-pane fade <?=$first ? 'show active' : ''?>" id="pane-<?=$dim?>" role="tabpanel">
-                <div class="row g-3">
-                    <?php foreach ($block['current'] as $metricRow): ?>
+                <?php if (empty($block['current'])): ?>
+                    <div class="alert alert-info">
+                        Нет данных по этому сегменту для выбранного статуса и периода.
+                    </div>
+                <?php else: ?>
+                    <div class="row g-3">
+                        <?php foreach ($block['current'] as $metricRow): ?>
                         <?php
                         $value = $metricRow['dimension_value'];
                         $prev = $previousMap[$value] ?? $defaultPrev;
@@ -302,8 +329,9 @@ $positiveDeltaIsGood = $selectedStatusValue !== 3;
                                 </div>
                             </div>
                         </div>
-                    <?php endforeach; ?>
-                </div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
             </div>
             <?php $first = false; endforeach; ?>
     </div>

--- a/public/templates/index13.phtml
+++ b/public/templates/index13.phtml
@@ -22,7 +22,8 @@ $summaryMetrics = [
     ['label' => 'Повторные клиенты', 'key' => 'repeat_customers', 'format' => 'number'],
     ['label' => 'Частота заказов', 'key' => 'avg_frequency', 'format' => 'decimal'],
 ];
-$chartConfigs = [];
+$summaryChartConfigs = [];
+$segmentChartConfigs = [];
 $currentPeriodDays = $start->diff($end)->days + 1;
 $previousPeriodDays = $prevStart->diff($prevEnd)->days + 1;
 $selectedStatusValue = isset($selectedStatuses[0]) ? (int) $selectedStatuses[0] : null;
@@ -132,9 +133,16 @@ $selectedStatusStats = $selectedStatusValue !== null
             $currentValue = $totals[$key] ?? 0;
             $previousValue = $totalsPrev[$key] ?? 0;
             $delta = MarketingDashboardFormatter::calculateDelta($currentValue, $previousValue);
-                    ?>
-                    <div class="col">
-                        <div class="card shadow-sm h-100">
+            $summaryChartId = 'summary_chart_' . $key;
+            $summaryChartConfigs[] = [
+                'id' => $summaryChartId,
+                'label' => $metric['label'],
+                'current' => (float) $currentValue,
+                'previous' => (float) $previousValue,
+            ];
+            ?>
+            <div class="col">
+                <div class="card shadow-sm h-100">
                     <div class="card-body">
                         <h6><?=htmlspecialchars($metric['label'])?></h6>
                         <strong><?=$formatValue($currentValue, $metric['format'])?></strong>
@@ -144,6 +152,7 @@ $selectedStatusStats = $selectedStatusValue !== null
                             (<?=MarketingDashboardFormatter::formatDelta($delta)?>)
                         </div>
 
+                        <canvas id="<?=htmlspecialchars($summaryChartId)?>" height="90" class="mt-3"></canvas>
                     </div>
                 </div>
             </div>
@@ -198,8 +207,9 @@ $selectedStatusStats = $selectedStatusValue !== null
                         $newCustomersDelta = MarketingDashboardFormatter::calculateDelta($metricRow['new_customers'] ?? 0, $prev['new_customers'] ?? 0);
                         $repeatCustomersDelta = MarketingDashboardFormatter::calculateDelta($metricRow['repeat_customers'] ?? 0, $prev['repeat_customers'] ?? 0);
                         $frequencyDelta = MarketingDashboardFormatter::calculateDelta($metricRow['avg_frequency'] ?? 0, $prev['avg_frequency'] ?? 0);
-                        $chartConfigs[] = [
+                        $segmentChartConfigs[] = [
                             'id' => $chartId,
+                            'label' => 'Выручка',
                             'current' => (float) ($metricRow['total_revenue'] ?? 0),
                             'previous' => (float) ($prev['total_revenue'] ?? 0),
                         ];
@@ -323,8 +333,10 @@ $selectedStatusStats = $selectedStatusValue !== null
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-    const chartConfigs = <?=json_encode($chartConfigs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)?>;
-    chartConfigs.forEach((config) => {
+    const summaryChartConfigs = <?=json_encode($summaryChartConfigs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)?>;
+    const segmentChartConfigs = <?=json_encode($segmentChartConfigs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)?>;
+
+    const renderComparisonChart = (config, colors) => {
         const canvas = document.getElementById(config.id);
         if (!canvas) {
             return;
@@ -335,17 +347,48 @@ $selectedStatusStats = $selectedStatusValue !== null
             data: {
                 labels: ['Текущий', 'Предыдущий'],
                 datasets: [{
-                    label: 'Выручка',
+                    label: config.label,
                     data: [config.current, config.previous],
-                    backgroundColor: ['rgba(54, 162, 235, 0.7)', 'rgba(200, 200, 200, 0.7)'],
+                    backgroundColor: colors,
+                    borderRadius: 4,
+                    maxBarThickness: 36,
                 }],
             },
             options: {
                 responsive: true,
-                plugins: { legend: { display: false } },
-                scales: { y: { beginAtZero: true } },
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        display: false,
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label(context) {
+                                const value = context.parsed.y ?? context.parsed;
+                                return `${context.dataset.label}: ${value.toLocaleString('ru-RU')}`;
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        grid: { display: false },
+                    },
+                    y: {
+                        beginAtZero: true,
+                        grid: { color: 'rgba(0,0,0,0.05)' },
+                    },
+                },
             },
         });
+    };
+
+    summaryChartConfigs.forEach((config) => {
+        renderComparisonChart(config, ['rgba(75, 192, 192, 0.7)', 'rgba(201, 203, 207, 0.5)']);
+    });
+
+    segmentChartConfigs.forEach((config) => {
+        renderComparisonChart(config, ['rgba(54, 162, 235, 0.7)', 'rgba(200, 200, 200, 0.7)']);
     });
 </script>
 </body>

--- a/src/Analytics/MarketingDashboardFormatter.php
+++ b/src/Analytics/MarketingDashboardFormatter.php
@@ -44,18 +44,18 @@ class MarketingDashboardFormatter
         return round((($current ?? 0) - $previous) / $previous * 100, 1);
     }
 
-    public static function deltaClass(?float $delta): string
+    public static function deltaClass(?float $delta, bool $positiveIsGood = true): string
     {
         if ($delta === null) {
             return 'delta-null';
         }
 
         if ($delta > 0) {
-            return 'delta-up';
+            return $positiveIsGood ? 'delta-up' : 'delta-down';
         }
 
         if ($delta < 0) {
-            return 'delta-down';
+            return $positiveIsGood ? 'delta-down' : 'delta-up';
         }
 
         return 'delta-null';

--- a/src/Analytics/MarketingDashboardService.php
+++ b/src/Analytics/MarketingDashboardService.php
@@ -220,7 +220,7 @@ class MarketingDashboardService
 
     /**
      * @param array<int, int> $statuses
-     * @return array{sql: string, params: array<int, array<int, int>>}
+     * @return array{0: string, 1: array<int, mixed>}
      */
     private function buildStatusClause(string $alias, array $statuses): array
     {
@@ -228,13 +228,10 @@ class MarketingDashboardService
         sort($clean);
 
         if ($clean === []) {
-            return ['sql' => '', 'params' => []];
+            return ['', []];
         }
 
-        return [
-            'sql' => sprintf(' AND %s.status IN (?a)', $alias),
-            'params' => [$clean],
-        ];
+        return [sprintf(' AND %s.status IN (?a)', $alias), [$clean]];
     }
 
     private function resolveField(string $dimension): string

--- a/src/Analytics/MarketingDashboardService.php
+++ b/src/Analytics/MarketingDashboardService.php
@@ -206,6 +206,31 @@ class MarketingDashboardService
     }
 
     /**
+     * @return array<int, array{total_orders: int, total_revenue: float}>
+     */
+    public function getStatusSummary(DateTime $start, DateTime $end): array
+    {
+        $rows = $this->analytics->getAll(
+            'SELECT status, COUNT(*) AS total_orders, SUM(total_sum) AS total_revenue
+             FROM analytics_orders
+            WHERE order_date BETWEEN ?s AND ?s
+            GROUP BY status',
+            [$start->format('Y-m-d'), $end->format('Y-m-d')]
+        );
+
+        $summary = [];
+        foreach ($rows as $row) {
+            $status = (int) ($row['status'] ?? 0);
+            $summary[$status] = [
+                'total_orders' => (int) ($row['total_orders'] ?? 0),
+                'total_revenue' => (float) ($row['total_revenue'] ?? 0),
+            ];
+        }
+
+        return $summary;
+    }
+
+    /**
      * @return array<int, int>
      */
     public function getAvailableStatuses(): array


### PR DESCRIPTION
## Summary
- добавлен выбор статусов заказов при формировании дашборда и получение доступных статусов из базы
- обновлены карточки сводных метрик: добавлены мини-гистограммы и подсказки, улучшено отображение выбранных статусов
- модифицированы сервисные запросы, чтобы учитывать выбранные статусы во всех расчётах и выборках

## Testing
- php -l public/index13.php
- php -l public/templates/index13.phtml
- php -l src/Analytics/MarketingDashboardService.php

------
https://chatgpt.com/codex/tasks/task_e_68cf08f61fac832b9a12b1614f654e22